### PR TITLE
Add writer option to Client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,4 @@ build/
 dist/
 *.egg-info/
 __pycache__
-
-.idea
-.vscode
+.venv

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ build/
 dist/
 *.egg-info/
 __pycache__
-.venv

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build/
 dist/
 *.egg-info/
 __pycache__
+.venv

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ td-spark*
 build/
 dist/
 *.egg-info/
+__pycache__
+
+.idea
+.vscode

--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ df = pd.DataFrame(data={'col1': [1, 2], 'col2': [3, 10]})
 client.load_table_from_dataframe(df, 'takuti.foo', if_exists='overwrite')
 ```
 
+If you want to use existing td-spark JAR file, creating `SparkWriter` with `td_spark_path` option would be helpful.
+
+```py
+writer = pytd.writer.SparkWriter(apikey='1/XXX', endpoint='https://api.treasuredata.com/', td_spark_path='/path/to/td-spark-assembly.jar')
+client = pytd.Client(database='sample_datasets', writer=writer)
+client.load_table_from_dataframe(df, 'mydb.bar', if_exists='overwrite')
+```
+
 ### DB-API
 
 `pytd` implements [Python Database API Specification v2.0](https://www.python.org/dev/peps/pep-0249/) with the help of [prestodb/presto-python-client](https://github.com/prestodb/presto-python-client).
@@ -120,7 +128,7 @@ for index, row in iterrows('select symbol, count(1) as cnt from nasdaq group by 
 First, install the package from PyPI:
 
 ```sh
-pip install pytd  
+pip install pytd
 # or, `pip install pytd[spark]` if you wish to use `to_td`
 ```
 
@@ -147,3 +155,21 @@ In [1]: %%load_ext pytd.pandas_td.ipython
 ```
 
 Consequently, all `pandas_td` code should keep running correctly with `pytd`. Report an issue from [here](https://github.com/treasure-data/pytd/issues/new) if you noticed any incompatible behaviors.
+
+### Use existing td-spark-assembly.jar file
+
+If you want to use existing td-spark JAR file, creating `SparkWriter` with `td_spark_path` option would be helpful. You can pass a writer to `connect()` function.
+
+```py
+import pytd
+import pytd.pandas_td as td
+import pandas as pd
+apikey = '1/XXX'
+endpoint = 'https://api.treasuredata.com/'
+
+writer = pytd.writer.SparkWriter(apikey=apikey, endpoint=endpoint, td_spark_path='/path/to/td-spark-assembly.jar')
+con = td.connect(apikey=apikey, endpoint=endpoint, writer=writer)
+
+df = pd.DataFrame(data={'col1': [1, 2], 'col2': [3, 10]})
+td.to_td(df, 'mydb.buzz', con, if_exists='replace', index=False)
+```

--- a/pytd/client.py
+++ b/pytd/client.py
@@ -161,7 +161,8 @@ class Client(object):
         if_exists : {'error', 'overwrite', 'append', 'ignore'}, default: 'error'
             What happens when a target table already exists.
         """
-        self.writer = SparkWriter(self.apikey, self.endpoint)
+        if self.writer is None:
+            self.writer = SparkWriter(self.apikey, self.endpoint)
 
         self.writer.write_dataframe(dataframe, self.database, table, if_exists)
 

--- a/pytd/client.py
+++ b/pytd/client.py
@@ -35,9 +35,15 @@ class Client(object):
     header : string or boolean, default: True
         Prepend comment strings, in the form "-- comment", as a header of queries.
         Set False to disable header.
+
+    writer : pytd.writer.Writer or child class of Writer class, optional
+        A Writer to choose writing method to Treasure Data. If not given, default Writer
+        will be created with executing :func:`~pytd.Client.load_table_from_dataframe`
+        at the first time.
     """
 
-    def __init__(self, apikey=None, endpoint=None, database='sample_datasets', engine='presto', header=True, **kwargs):
+    def __init__(
+            self, apikey=None, endpoint=None, database='sample_datasets', engine='presto', header=True, writer=None, **kwargs):
         if isinstance(engine, QueryEngine):
             apikey = engine.apikey
             endpoint = engine.endpoint
@@ -57,7 +63,7 @@ class Client(object):
 
         self.api_client = tdclient.Client(apikey=apikey, endpoint=endpoint, user_agent=engine.user_agent, **kwargs)
 
-        self.writer = None
+        self.writer = writer
 
     def list_databases(self):
         """Get a list of td-client-python Database objects.

--- a/pytd/client.py
+++ b/pytd/client.py
@@ -63,6 +63,7 @@ class Client(object):
 
         self.api_client = tdclient.Client(apikey=apikey, endpoint=endpoint, user_agent=engine.user_agent, **kwargs)
 
+        self.managed_writer = False
         self.writer = writer
 
     def list_databases(self):
@@ -119,7 +120,7 @@ class Client(object):
         """
         self.engine.close()
         self.api_client.close()
-        if self.writer is not None:
+        if self.writer is not None and self.managed_writer:
             self.writer.close()
 
     def query(self, query):
@@ -161,6 +162,7 @@ class Client(object):
             What happens when a target table already exists.
         """
         if self.writer is None:
+            self.managed_writer = True
             self.writer = SparkWriter(self.apikey, self.endpoint)
 
         self.writer.write_dataframe(dataframe, self.database, table, if_exists)

--- a/pytd/client.py
+++ b/pytd/client.py
@@ -63,7 +63,7 @@ class Client(object):
 
         self.api_client = tdclient.Client(apikey=apikey, endpoint=endpoint, user_agent=engine.user_agent, **kwargs)
 
-        self.managed_writer = False
+        self.managed_writer = writer is None
         self.writer = writer
 
     def list_databases(self):
@@ -120,7 +120,7 @@ class Client(object):
         """
         self.engine.close()
         self.api_client.close()
-        if self.writer is not None and self.managed_writer:
+        if self.managed_writer and self.writer is not None:
             self.writer.close()
 
     def query(self, query):
@@ -161,9 +161,7 @@ class Client(object):
         if_exists : {'error', 'overwrite', 'append', 'ignore'}, default: 'error'
             What happens when a target table already exists.
         """
-        if self.writer is None:
-            self.managed_writer = True
-            self.writer = SparkWriter(self.apikey, self.endpoint)
+        self.writer = SparkWriter(self.apikey, self.endpoint)
 
         self.writer.write_dataframe(dataframe, self.database, table, if_exists)
 

--- a/pytd/pandas_td/__init__.py
+++ b/pytd/pandas_td/__init__.py
@@ -274,7 +274,7 @@ def _parse_dates(frame, parse_dates):
 read_td = read_td_query
 
 
-def to_td(frame, name, con, if_exists='fail', time_col=None, time_index=None, index=True, index_label=None, chunksize=10000, date_format=None, writer=None):
+def to_td(frame, name, con, if_exists='fail', time_col=None, time_index=None, index=True, index_label=None, chunksize=10000, date_format=None):
     """Write a DataFrame to a Treasure Data table.
 
     This method converts the dataframe into a series of key-value pairs
@@ -327,10 +327,6 @@ def to_td(frame, name, con, if_exists='fail', time_col=None, time_index=None, in
 
     date_format : string, default: None
         Format string for datetime objects
-
-    writer : pytd.writer.Writer or child class of Writer class, optional
-        A Writer to choose writing method to Treasure Data. If not given, default Writer
-        will be created.
     """
     if if_exists == 'fail' or if_exists == 'error':
         mode = 'error'
@@ -349,9 +345,9 @@ def to_td(frame, name, con, if_exists='fail', time_col=None, time_index=None, in
     frame = _convert_index_column(frame, index, index_label)
     frame = _convert_date_format(frame, date_format)
 
-    if writer is None:
-        writer = SparkWriter(con.apikey, con.endpoint)
-    writer.write_dataframe(frame, con.database, name, mode)
+    if con.writer is None:
+        con.writer = SparkWriter(con.apikey, con.endpoint)
+    con.writer.write_dataframe(frame, con.database, name, mode)
 
 
 def _convert_time_column(frame, time_col=None, time_index=None):

--- a/pytd/pandas_td/__init__.py
+++ b/pytd/pandas_td/__init__.py
@@ -345,9 +345,7 @@ def to_td(frame, name, con, if_exists='fail', time_col=None, time_index=None, in
     frame = _convert_index_column(frame, index, index_label)
     frame = _convert_date_format(frame, date_format)
 
-    if con.writer is None:
-        con.writer = SparkWriter(con.apikey, con.endpoint)
-    con.writer.write_dataframe(frame, con.database, name, mode)
+    con.load_table_from_dataframe(frame, name, mode)
 
 
 def _convert_time_column(frame, time_col=None, time_index=None):

--- a/pytd/pandas_td/__init__.py
+++ b/pytd/pandas_td/__init__.py
@@ -274,7 +274,7 @@ def _parse_dates(frame, parse_dates):
 read_td = read_td_query
 
 
-def to_td(frame, name, con, if_exists='fail', time_col=None, time_index=None, index=True, index_label=None, chunksize=10000, date_format=None):
+def to_td(frame, name, con, if_exists='fail', time_col=None, time_index=None, index=True, index_label=None, chunksize=10000, date_format=None, writer=None):
     """Write a DataFrame to a Treasure Data table.
 
     This method converts the dataframe into a series of key-value pairs
@@ -327,6 +327,10 @@ def to_td(frame, name, con, if_exists='fail', time_col=None, time_index=None, in
 
     date_format : string, default: None
         Format string for datetime objects
+
+    writer : pytd.writer.Writer or child class of Writer class, optional
+        A Writer to choose writing method to Treasure Data. If not given, default Writer
+        will be created.
     """
     if if_exists == 'fail' or if_exists == 'error':
         mode = 'error'
@@ -345,7 +349,8 @@ def to_td(frame, name, con, if_exists='fail', time_col=None, time_index=None, in
     frame = _convert_index_column(frame, index, index_label)
     frame = _convert_date_format(frame, date_format)
 
-    writer = SparkWriter(con.apikey, con.endpoint)
+    if writer is None:
+        writer = SparkWriter(con.apikey, con.endpoint)
     writer.write_dataframe(frame, con.database, name, mode)
 
 

--- a/pytd/tests/test_client.py
+++ b/pytd/tests/test_client.py
@@ -16,7 +16,6 @@ class ClientTestCase(unittest.TestCase):
         self.client.writer = MagicMock()
         self.client.close()
         self.assertTrue(self.client.engine.close.called)
-        self.assertFalse(self.client.writer.close.called)
 
     def query(self):
         d = self.client.query('select * from tbl')
@@ -41,6 +40,7 @@ class ClientTestWithoutWriter(ClientTestCase):
 
     def test_close(self):
         self.close()
+        self.assertTrue(self.client.writer.close.called)
 
     def test_query(self):
         self.query()
@@ -75,6 +75,7 @@ class ClientTestWithWriter(ClientTestCase):
 
     def test_close(self):
         self.close()
+        self.assertFalse(self.client.writer.close.called)
 
     def test_query(self):
         self.query()

--- a/pytd/tests/test_client.py
+++ b/pytd/tests/test_client.py
@@ -48,8 +48,8 @@ class ClientTestWithoutWriter(ClientTestCase):
     def test_load_table_from_dataframe(self):
         df = pd.DataFrame([[1, 2], [3, 4]])
         self.assertTrue(self.client.writer is None)
+        self.assertTrue(self.client.managed_writer)
         self.client.writer = MagicMock()
-        self.client.managed_writer = True
 
         self.client.load_table_from_dataframe(df, 'foo', 'error')
         self.assertTrue(self.client.writer.write_dataframe.called)
@@ -83,9 +83,9 @@ class ClientTestWithWriter(ClientTestCase):
     def test_load_table_from_dataframe(self):
         df = pd.DataFrame([[1, 2], [3, 4]])
         self.assertTrue(self.client.writer is self.writer)
+        self.assertFalse(self.client.managed_writer)
 
         self.client.load_table_from_dataframe(df, 'foo', 'error')
-        self.assertFalse(self.client.managed_writer)
         self.assertTrue(self.client.writer.write_dataframe.called)
         self.client.close()
         self.assertFalse(self.client.writer.close.called)

--- a/pytd/tests/test_client.py
+++ b/pytd/tests/test_client.py
@@ -11,9 +11,30 @@ except ImportError:
 
 
 class ClientTestCase(unittest.TestCase):
+    def close(self):
+        self.assertTrue(self.client.writer is self.writer)
+        self.client.writer = MagicMock()
+        self.client.close()
+        self.assertTrue(self.client.engine.close.called)
+        self.assertTrue(self.client.writer.close.called)
 
+    def query(self):
+        d = self.client.query('select * from tbl')
+        self.assertListEqual(d['columns'], ['col1', 'col2'])
+        self.assertListEqual(d['data'], [[1, 'a'], [2, 'b']])
+
+    def load_table_from_dataframe(self):
+        df = pd.DataFrame([[1, 2], [3, 4]])
+        self.assertTrue(self.client.writer is self.writer)
+        self.client.writer = MagicMock()
+        self.client.load_table_from_dataframe(df, 'foo', 'error')
+        self.assertTrue(self.client.writer.write_dataframe.called)
+
+
+class ClientTestWithoutWriter(ClientTestCase):
     @patch.object(Client, '_fetch_query_engine', return_value=MagicMock())
     def setUp(self, fetch_query_engine):
+        self.writer = None
         self.client = Client(apikey='APIKEY', endpoint='ENDPOINT', database='sample_datasets')
         self.assertEqual(self.client.apikey, 'APIKEY')
         self.assertEqual(self.client.endpoint, 'ENDPOINT')
@@ -26,23 +47,39 @@ class ClientTestCase(unittest.TestCase):
         self.client.engine.execute = MagicMock(return_value=res)
 
     def test_close(self):
-        self.assertTrue(self.client.writer is None)
-        self.client.writer = MagicMock()
-        self.client.close()
-        self.assertTrue(self.client.engine.close.called)
-        self.assertTrue(self.client.writer.close.called)
+        self.close()
 
     def test_query(self):
-        d = self.client.query('select * from tbl')
-        self.assertListEqual(d['columns'], ['col1', 'col2'])
-        self.assertListEqual(d['data'], [[1, 'a'], [2, 'b']])
+        self.query()
 
     def test_load_table_from_dataframe(self):
-        df = pd.DataFrame([[1, 2], [3, 4]])
-        self.assertTrue(self.client.writer is None)
-        self.client.writer = MagicMock()
-        self.client.load_table_from_dataframe(df, 'foo', 'error')
-        self.assertTrue(self.client.writer.write_dataframe.called)
+        self.load_table_from_dataframe()
+
+
+class ClientTestWithWriter(ClientTestCase):
+
+    @patch.object(Client, '_fetch_query_engine', return_value=MagicMock())
+    def setUp(self, fetch_query_engine):
+        self.writer = MagicMock()
+        self.client = Client(apikey='APIKEY', endpoint='ENDPOINT', database='sample_datasets', writer=self.writer)
+        self.assertEqual(self.client.apikey, 'APIKEY')
+        self.assertEqual(self.client.endpoint, 'ENDPOINT')
+        self.assertEqual(self.client.database, 'sample_datasets')
+
+        self.assertTrue(fetch_query_engine.called)
+        self.client.engine = MagicMock()
+
+        res = {'columns': ['col1', 'col2'], 'data': [[1, 'a'], [2, 'b']]}
+        self.client.engine.execute = MagicMock(return_value=res)
+
+    def test_close(self):
+        self.close()
+
+    def test_query(self):
+        self.query()
+
+    def test_load_table_from_dataframe(self):
+        self.load_table_from_dataframe()
 
 
 def test_client_context():


### PR DESCRIPTION
Currently, we have no way to set `Writer` with initialization for the `Client` class. This PR adds writer option to Client.

Confirmed with the following sequence as well as with adding unittest.

```py
In [1]: import pytd

In [2]: import td_pyspark

In [3]: jar_path = td_pyspark.TDSparkContextBuilder.default_jar_path()

In [5]: import os

In [6]: writer = pytd.writer.SparkWriter(apikey=os.getenv('TD_API_KEY'), endpoint=os.getenv('TD_API_SERVER'), td_spark_path=ja
   ...: r_path)
19/07/02 15:01:19 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
Using Spark's default log4j profile: org/apache/spark/log4j-defaults.properties
Setting default log level to "WARN".
To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).

In [7]: client = pytd.Client(writer=writer)

In [9]: import pandas as pd

In [10]: df = pd.DataFrame({'a':[1, 2], 'b':[3, 4]})

In [12]: client.load_table_from_dataframe(df, 'aki.test_pytd', if_exists='overwrite')
2019-07-02T15:02:29.491+0900 debug [spark] Loading com.treasuredata.spark package - (package.scala:23)
2019-07-02T15:02:29.558+0900  info [spark] td-spark version:19.7.0+1-6cc7a4ac, revision:6cc7a4a, build_time:2019-07-02T11:47:51.206+0900 - (package.scala:24)
2019-07-02T15:02:29.666+0900  info [TDServiceConfig] td-spark site: eu01 - (TDServiceConfig.scala:36)
2019-07-02T15:02:31.952+0900  info [LifeCycleManager] [session:49547178] Starting a new lifecycle ... - (LifeCycleManager.scala:187)
2019-07-02T15:02:31.957+0900  info [LifeCycleManager] [session:49547178] ======== STARTED ======== - (LifeCycleManager.scala:191)
2019-07-02T15:02:34.420+0900  warn [DefaultSource] Dropping aki.test_pytd (Overwrite mode) - (DefaultSource.scala:94)
2019-07-02T15:02:35.039+0900  info [TDWriter] Uploading data to aki.test_pytd (mode: Overwrite) - (TDWriter.scala:66)
2019-07-02T15:02:36.679+0900  info [TDWriter] [txx:b6fcb8a2] Starting a new transaction for updating aki.test_pytd - (TDWriter.scala:95)
2019-07-02T15:02:43.447+0900  info [TDWriter] [txx:b6fcb8a2] Finished uploading 1 partitions (2 records, size:127B) to aki.test_pytd - (TDWriter.scala:132)
```