### PR TITLE
Add spark_configs for additional setting to SparkConf

### DIFF
--- a/pytd/writer.py
+++ b/pytd/writer.py
@@ -451,10 +451,9 @@ class SparkWriter(Writer):
             site = "eu01"
         conf.set("spark.td.site", site)
 
-        if spark_configs is None:
-            spark_configs = {}
-        for k, v in spark_configs.items():
-            conf.set(k, v)
+        if isinstance(spark_configs, dict):
+            for k, v in spark_configs.items():
+                conf.set(k, v)
 
         try:
             return SparkSession.builder.config(conf=conf).getOrCreate()


### PR DESCRIPTION
This is a workaround to set additional `SparkConf` via `SparkConf.get`. Unfortunately, I didn't come up with writing an appropriate unit test for it.

I tested manually as follows:

```python
In [1]: import os

In [2]: from td_pyspark import TDSparkContextBuilder

In [3]: import pytd
   ...: import pytd.pandas_td as td
   ...: import pandas as pd

In [5]: jar_path = TDSparkContextBuilder.default_jar_path()

In [6]: spark_conf = {"spark.executor.memory": "2g", "spark.driver.memory": "1g"}

In [11]: df = pd.DataFrame(data={'col1': [1, 2], 'col2': [3, 10]})

In [12]: db = 'aki'

In [13]: table = 'pytd_test'

In [14]: client = pytd.Client(database=db)

In [15]: tbl = client.get_table(db, table)

In [16]: tbl.import_dataframe(df, writer=writer, if_exists='overwrite')
19/07/23 11:07:29 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
Using Spark's default log4j profile: org/apache/spark/log4j-defaults.properties
Setting default log level to "WARN".
To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).
2019-07-23T11:07:33.739+0900 debug [spark] Loading com.treasuredata.spark package - (package.scala:23)
2019-07-23T11:07:33.853+0900  info [spark] td-spark version:19.7.0+1-6cc7a4ac, revision:6cc7a4a, build_time:2019-07-02T11:47:51.206+0900 - (package.scala:24)
2019-07-23T11:07:33.933+0900  info [TDServiceConfig] td-spark site: us - (TDServiceConfig.scala:36)
2019-07-23T11:07:35.467+0900  info [LifeCycleManager] [session:47cba716] Starting a new lifecycle ... - (LifeCycleManager.scala:187)
2019-07-23T11:07:35.469+0900  info [LifeCycleManager] [session:47cba716] ======== STARTED ======== - (LifeCycleManager.scala:191)
2019-07-23T11:07:37.333+0900  warn [DefaultSource] Dropping aki.pytd_test (Overwrite mode) - (DefaultSource.scala:94)
2019-07-23T11:07:37.992+0900  info [TDWriter] Uploading data to aki.pytd_test (mode: Overwrite) - (TDWriter.scala:66)
2019-07-23T11:07:39.268+0900  info [TDWriter] [txx:f33b67ad] Starting a new transaction for updating aki.pytd_test - (TDWriter.scala:95)
2019-07-23T11:07:45.912+0900  info [TDWriter] [txx:f33b67ad] Finished uploading 1 partitions (2 records, size:132B) to aki.pytd_test - (TDWriter.scala:132)

In [17]: assert writer.td_spark.conf.get('spark.executor.memory') == '2g'

In [18]: assert writer.td_spark.conf.get('spark.driver.memory') == '1g'
```