### PR TITLE
Use default_engine for cursor

### DIFF
--- a/pytd/dbapi/connection.py
+++ b/pytd/dbapi/connection.py
@@ -30,7 +30,7 @@ class Connection(object):
         raise NotSupportedError
 
     def cursor(self):
-        return self.client.engine.cursor()
+        return self.client.default_engine.cursor()
 
     def __enter__(self):
         return self

--- a/pytd/dbapi/tests/test_connection.py
+++ b/pytd/dbapi/tests/test_connection.py
@@ -21,7 +21,7 @@ class ConnectionTestCase(unittest.TestCase):
 
     def test_cursor(self):
         self.conn.cursor()
-        self.mock_client.engine.cursor.assert_called_with()
+        self.mock_client.default_engine.cursor.assert_called_with()
 
 
 def test_connection_context():


### PR DESCRIPTION
fix #29 

Tested manually as follows:

```py
In [2]: from pytd.dbapi import connect

In [5]: import pytd

In [6]: conn = connect(pytd.Client(database='sample_datasets'))

In [7]: conn.cursor()
Out[7]: <prestodb.dbapi.Cursor at 0x10a2b94e0>

In [8]: conn = connect(pytd.Client(database='sample_datasets', default_engine='hive'))

In [9]: conn.cursor()
Out[9]: <tdclient.cursor.Cursor at 0x10a230748>

In [11]: conn = connect(pytd.Client(database='sample_datasets'))

In [12]: def query(sql, connection):
    ...:     cur = connection.cursor()
    ...:     cur.execute(sql)
    ...:     rows = cur.fetchall()
    ...:     columns = [desc[0] for desc in cur.description]
    ...:     return {'data': rows, 'columns': columns}
    ...:
    ...: query('select code, count(1) as cnt from www_access group by 1 order by 2 desc', conn)
Out[12]: {'data': [[200, 4981], [404, 17], [500, 2]], 'columns': ['code', 'cnt']}

In [19]: conn = connect(pytd.Client(database='sample_datasets', default_engine='hive'))

In [20]: query('select code, count(1) as cnt from www_access group by code', conn)
Out[20]: {'data': [[200, 4981], [404, 17], [500, 2]], 'columns': ['code', 'cnt']}
```