### PR TITLE
Add warn message for HiveQueryEngine#cursor

### DIFF
--- a/pytd/query_engine.py
+++ b/pytd/query_engine.py
@@ -201,6 +201,12 @@ class HiveQueryEngine(QueryEngine):
         -------
         tdclient.cursor.Cursor
         """
+        logger.warning(
+            "returning `tdclient.cursor.Cursor`. This cursor, `Cursor#fetchone` "
+            "in particular, might behave different from your expectation, "
+            "because it actually executes a job on Treasure Data and fetches all "
+            "records at once from the job result."
+        )
         return self.engine.cursor()
 
     def close(self):


### PR DESCRIPTION
resolve #33 

```py
>>> import pytd
>>> from pytd.dbapi import connect
>>>
>>>
>>> conn = connect(pytd.Client(database='sample_datasets', default_engine='hive'))
>>> conn.cursor()
returning `tdclient.cursor.Cursor`. This cursor, `Cursor#fetchone` in particular, might behave different from your expectation, because it actually executes a job on Treasure Data and fetches all records at once from the job result.
<tdclient.cursor.Cursor object at 0x103942b38>
```