### PR TITLE
Provide an option to use TD API in PrestoQueryEngine

### DIFF
--- a/pytd/client.py
+++ b/pytd/client.py
@@ -241,7 +241,8 @@ class Client(object):
 
     def _fetch_query_engine(self, engine, apikey, endpoint, database, header):
         if engine == "presto":
-            return PrestoQueryEngine(apikey, endpoint, database, header)
+            host = PrestoQueryEngine.get_api_host(endpoint)
+            return PrestoQueryEngine(apikey, host, database, header)
         elif engine == "hive":
             return HiveQueryEngine(apikey, endpoint, database, header)
         else:

--- a/pytd/client.py
+++ b/pytd/client.py
@@ -133,7 +133,7 @@ class Client(object):
         self.default_engine.close()
         self.api_client.close()
 
-    def query(self, query, engine=None):
+    def query(self, query, engine=None, **kwargs):
         """Run query and get results.
 
         Parameters
@@ -176,7 +176,7 @@ class Client(object):
         else:
             engine = self.default_engine
         header = engine.create_header("Client#query")
-        return engine.execute(header + query)
+        return engine.execute(header + query, **kwargs)
 
     def get_table(self, database, table):
         """Create a pytd table control instance.

--- a/pytd/client.py
+++ b/pytd/client.py
@@ -241,8 +241,7 @@ class Client(object):
 
     def _fetch_query_engine(self, engine, apikey, endpoint, database, header):
         if engine == "presto":
-            host = PrestoQueryEngine.get_api_host(endpoint)
-            return PrestoQueryEngine(apikey, host, database, header)
+            return PrestoQueryEngine(apikey, endpoint, database, header)
         elif engine == "hive":
             return HiveQueryEngine(apikey, endpoint, database, header)
         else:

--- a/pytd/pandas_td/__init__.py
+++ b/pytd/pandas_td/__init__.py
@@ -80,10 +80,9 @@ def create_engine(url, con=None, header=True, show_progress=5.0, clear_progress=
         else:
             raise ValueError("invalid engine descriptor format")
 
-        endpoint = "https://api.treasuredata.com"
-
-    if con is not None:
-        apikey, endpoint = con.apikey, con.endpoint
+    if con is None:
+        con = connect(apikey=apikey, endpoint=endpoint)
+    apikey, endpoint = con.apikey, con.endpoint
 
     if engine_type == "presto":
         return PrestoQueryEngine(apikey, endpoint, database, header=header)

--- a/pytd/pandas_td/__init__.py
+++ b/pytd/pandas_td/__init__.py
@@ -176,7 +176,7 @@ def read_td_job(job_id, engine, index_col=None, parse_dates=None):
     -------
     DataFrame
     """
-    con = connect(engine=engine)
+    con = connect(default_engine=engine)
 
     # get job
     job = con.get_job(job_id)

--- a/pytd/pandas_td/__init__.py
+++ b/pytd/pandas_td/__init__.py
@@ -80,9 +80,10 @@ def create_engine(url, con=None, header=True, show_progress=5.0, clear_progress=
         else:
             raise ValueError("invalid engine descriptor format")
 
-    if con is None:
-        con = connect(apikey=apikey, endpoint=endpoint)
-    apikey, endpoint = con.apikey, con.endpoint
+        endpoint = "https://api.treasuredata.com"
+
+    if con is not None:
+        apikey, endpoint = con.apikey, con.endpoint
 
     if engine_type == "presto":
         return PrestoQueryEngine(apikey, endpoint, database, header=header)
@@ -132,6 +133,9 @@ def read_td_query(
     -------
     DataFrame
     """
+    if params is None:
+        params = {}
+
     if isinstance(engine, PrestoQueryEngine) and distributed_join is not None:
         header = engine.create_header(
             [
@@ -144,7 +148,9 @@ def read_td_query(
     else:
         header = engine.create_header("read_td_query")
 
-    return _to_dataframe(engine.execute(header + query), index_col, parse_dates)
+    return _to_dataframe(
+        engine.execute(header + query, **params), index_col, parse_dates
+    )
 
 
 def read_td_job(job_id, engine, index_col=None, parse_dates=None):

--- a/pytd/query_engine.py
+++ b/pytd/query_engine.py
@@ -134,6 +134,17 @@ class PrestoQueryEngine(QueryEngine):
         """
         return "pytd/{0} (prestodb/{1})".format(__version__, prestodb.__version__)
 
+    @property
+    def api_host(self):
+        """Presto API host obtained from ``TD_PRESTO_API`` env variable or
+        inferred from Treasure Data REST API endpoint.
+        """
+        http = re.compile(r"https?://")
+        return os.getenv(
+            "TD_PRESTO_API",
+            http.sub("", self.endpoint).strip("/").replace("api", "api-presto"),
+        )
+
     def cursor(self):
         """Get cursor defined by DB-API.
 
@@ -149,14 +160,8 @@ class PrestoQueryEngine(QueryEngine):
         self.engine.close()
 
     def _connect(self):
-        http = re.compile(r"https?://")
-        api_presto = os.getenv(
-            "TD_PRESTO_API",
-            http.sub("", self.endpoint).strip("/").replace("api", "api-presto"),
-        )
-
         return prestodb.dbapi.connect(
-            host=api_presto,
+            host=self.api_host,
             port=443,
             http_scheme="https",
             user=self.apikey,

--- a/pytd/query_engine.py
+++ b/pytd/query_engine.py
@@ -1,7 +1,7 @@
 import abc
 import logging
 import os
-import re
+from urllib.parse import urlparse
 
 import prestodb
 import tdclient
@@ -139,10 +139,8 @@ class PrestoQueryEngine(QueryEngine):
         """Presto API host obtained from ``TD_PRESTO_API`` env variable or
         inferred from Treasure Data REST API endpoint.
         """
-        http = re.compile(r"https?://")
         return os.getenv(
-            "TD_PRESTO_API",
-            http.sub("", self.endpoint).strip("/").replace("api", "api-presto"),
+            "TD_PRESTO_API", urlparse(self.endpoint).netloc.replace("api", "api-presto")
         )
 
     def cursor(self):

--- a/pytd/query_engine.py
+++ b/pytd/query_engine.py
@@ -129,24 +129,33 @@ class QueryEngine(metaclass=abc.ABCMeta):
         -------
         tdclient.cursor.Cursor
         """
+        api_param_names = set(
+            [
+                "type",
+                "db",
+                "result_url",
+                "priority",
+                "retry_limit",
+                "wait_interval",
+                "wait_callback",
+            ]
+        )
+
+        # update a clone of the original params
+        cursor_kwargs = con._cursor_kwargs.copy()
+        for k, v in kwargs.items():
+            if k not in api_param_names:
+                raise RuntimeError(
+                    "unknown parameter for Treasure Data query execution API; "
+                    "'{}' is not in [{}].".format(k, ", ".join(api_param_names))
+                )
+            cursor_kwargs[k] = v
+
         # keep the original `_cursor_kwargs`
         original_cursor_kwargs = con._cursor_kwargs.copy()
 
         # overwrite the original params
-        if "type" in kwargs:
-            con._cursor_kwargs["type"] = kwargs["type"]
-        if "db" in kwargs:
-            con._cursor_kwargs["db"] = kwargs["db"]
-        if "result_url" in kwargs:
-            con._cursor_kwargs["result_url"] = kwargs["result_url"]
-        if "priority" in kwargs:
-            con._cursor_kwargs["priority"] = kwargs["priority"]
-        if "retry_limit" in kwargs:
-            con._cursor_kwargs["retry_limit"] = kwargs["retry_limit"]
-        if "wait_interval" in kwargs:
-            con._cursor_kwargs["wait_interval"] = kwargs["wait_interval"]
-        if "wait_callback" in kwargs:
-            con._cursor_kwargs["wait_callback"] = kwargs["wait_callback"]
+        con._cursor_kwargs = cursor_kwargs
 
         # `Connection#cursor` internally refers the customized
         # ``_cursor_kwargs``

--- a/pytd/tests/test_query_engine.py
+++ b/pytd/tests/test_query_engine.py
@@ -23,7 +23,7 @@ class PrestoQueryEngineTestCase(unittest.TestCase):
         )
 
     def test_api_host(self):
-        host = self.presto.api_host
+        host = PrestoQueryEngine.get_api_host(self.presto.endpoint)
         self.assertEqual(host, "api-presto.treasuredata.com")
 
     def test_create_header(self):

--- a/pytd/tests/test_query_engine.py
+++ b/pytd/tests/test_query_engine.py
@@ -56,6 +56,10 @@ class PrestoQueryEngineTestCase(unittest.TestCase):
         self.presto.cursor(priority="LOW")
         self.assertTrue(self.presto.tdclient_connection.cursor.called)
 
+    def test_cursor_with_unknown_params(self):
+        with self.assertRaises(RuntimeError):
+            self.presto.cursor(foo="LOW")
+
     def test_close(self):
         self.presto.close()
         self.assertTrue(self.presto.prestodb_connection.close.called)

--- a/pytd/tests/test_query_engine.py
+++ b/pytd/tests/test_query_engine.py
@@ -22,6 +22,10 @@ class PrestoQueryEngineTestCase(unittest.TestCase):
             ua, "pytd/{0} (prestodb/{1})".format(__version__, prestodb.__version__)
         )
 
+    def test_api_host(self):
+        host = self.presto.api_host
+        self.assertEqual(host, "api-presto.treasuredata.com")
+
     def test_create_header(self):
         presto_no_header = PrestoQueryEngine(
             "1/XXX", "https://api.treasuredata.com/", "sample_datasets", False


### PR DESCRIPTION
PrestoQueryEngine dynamically determines if it uses Presto or TD API depending on a value of `endpoint` arg.

If QueryEngine accesses to TD API, `QueryEngine#execute` now allows users to pass extra args `params` e.g., `params={'priority': 'LOW'}`.

This patch resolves #39