### PR TITLE
Disable query parameter `type`

### DIFF
--- a/pytd/client.py
+++ b/pytd/client.py
@@ -146,6 +146,25 @@ class Client(object):
             Query engine. If not given, default query engine created in the
             constructor will be used.
 
+        **kwargs
+            Treasure Data-specific optional query parameters. Giving these
+            keyword arguments forces query engine to issue a query via Treasure
+            Data REST API provided by ``tdclient``; that is, if ``engine`` is
+            Presto, you cannot enjoy efficient direct access to the query
+            engine provided by ``prestodb``.
+
+            - ``db`` (str): use the database
+            - ``result_url`` (str): result output URL
+            - ``priority`` (int or str): priority
+                - -2: "VERY LOW"
+                - -1: "LOW"
+                -  0: "NORMAL"
+                -  1: "HIGH"
+                -  2: "VERY HIGH"
+            - ``retry_limit`` (int): max number of automatic retries
+            - ``wait_interval`` (int): sleep interval until job finish
+            - ``wait_callback`` (function): called every interval against job itself
+
         Returns
         -------
         dict : keys ('data', 'columns')

--- a/pytd/pandas_td/__init__.py
+++ b/pytd/pandas_td/__init__.py
@@ -121,12 +121,23 @@ def read_td_query(
         See https://prestodb.io/docs/current/release/release-0.77.html
 
     params : dict, optional
-        Parameters to pass to execute method.
+        Parameters to pass to execute method. pytd does not support parameter
+        ``type`` ('hive', 'presto'), and query type needs to be defined by
+        ``engine``.
+
         Available parameters:
-        - result_url (str): result output URL
-        - priority (int or str): priority (e.g. "NORMAL", "HIGH", etc.)
-        - retry_limit (int): retry limit
-        pytd: This argument will be ignored.
+
+        - ``db`` (str): use the database
+        - ``result_url`` (str): result output URL
+        - ``priority`` (int or str): priority
+            - -2: "VERY LOW"
+            - -1: "LOW"
+            -  0: "NORMAL"
+            -  1: "HIGH"
+            -  2: "VERY HIGH"
+        - ``retry_limit`` (int): max number of automatic retries
+        - ``wait_interval`` (int): sleep interval until job finish
+        - ``wait_callback`` (function): called every interval against job itself
 
     Returns
     -------

--- a/pytd/query_engine.py
+++ b/pytd/query_engine.py
@@ -49,6 +49,24 @@ class QueryEngine(metaclass=abc.ABCMeta):
         query : string
             Query.
 
+        **kwargs
+            Treasure Data-specific optional query parameters. Giving these
+            keyword arguments forces query engine to issue a query via Treasure
+            Data REST API provided by ``tdclient``, rather than using a direct
+            connection established by the ``prestodb`` package.
+
+            - ``db`` (str): use the database
+            - ``result_url`` (str): result output URL
+            - ``priority`` (int or str): priority
+                - -2: "VERY LOW"
+                - -1: "LOW"
+                -  0: "NORMAL"
+                -  1: "HIGH"
+                -  2: "VERY HIGH"
+            - ``retry_limit`` (int): max number of automatic retries
+            - ``wait_interval`` (int): sleep interval until job finish
+            - ``wait_callback`` (function): called every interval against job itself
+
         Returns
         -------
         dict : keys ('data', 'columns')
@@ -124,6 +142,24 @@ class QueryEngine(metaclass=abc.ABCMeta):
         ----------
         con : tdclient.connection.Connection
             Handler created by ``tdclient#connect``.
+
+        **kwargs
+            Treasure Data-specific optional query parameters. Giving these
+            keyword arguments forces query engine to issue a query via Treasure
+            Data REST API provided by ``tdclient``, rather than using a direct
+            connection established by the ``prestodb`` package.
+
+            - ``db`` (str): use the database
+            - ``result_url`` (str): result output URL
+            - ``priority`` (int or str): priority
+                - -2: "VERY LOW"
+                - -1: "LOW"
+                -  0: "NORMAL"
+                -  1: "HIGH"
+                -  2: "VERY HIGH"
+            - ``retry_limit`` (int): max number of automatic retries
+            - ``wait_interval`` (int): sleep interval until job finish
+            - ``wait_callback`` (function): called every interval against job itself
 
         Returns
         -------
@@ -221,6 +257,26 @@ class PrestoQueryEngine(QueryEngine):
     def cursor(self, **kwargs):
         """Get cursor defined by DB-API.
 
+        Parameters
+        ----------
+        **kwargs
+            Treasure Data-specific optional query parameters. Giving these
+            keyword arguments forces query engine to issue a query via Treasure
+            Data REST API provided by ``tdclient``, rather than using a direct
+            connection established by the ``prestodb`` package.
+
+            - ``db`` (str): use the database
+            - ``result_url`` (str): result output URL
+            - ``priority`` (int or str): priority
+                - -2: "VERY LOW"
+                - -1: "LOW"
+                -  0: "NORMAL"
+                -  1: "HIGH"
+                -  2: "VERY HIGH"
+            - ``retry_limit`` (int): max number of automatic retries
+            - ``wait_interval`` (int): sleep interval until job finish
+            - ``wait_callback`` (function): called every interval against job itself
+
         Returns
         -------
         prestodb.dbapi.Cursor, or tdclient.cursor.Cursor
@@ -287,6 +343,25 @@ class HiveQueryEngine(QueryEngine):
 
     def cursor(self, **kwargs):
         """Get cursor defined by DB-API.
+
+        Parameters
+        ----------
+        **kwargs
+            Treasure Data-specific optional query parameters. Giving these
+            keyword arguments forces query engine to issue a query via Treasure
+            Data REST API provided by ``tdclient``.
+
+            - ``db`` (str): use the database
+            - ``result_url`` (str): result output URL
+            - ``priority`` (int or str): priority
+                - -2: "VERY LOW"
+                - -1: "LOW"
+                -  0: "NORMAL"
+                -  1: "HIGH"
+                -  2: "VERY HIGH"
+            - ``retry_limit`` (int): max number of automatic retries
+            - ``wait_interval`` (int): sleep interval until job finish
+            - ``wait_callback`` (function): called every interval against job itself
 
         Returns
         -------

--- a/pytd/query_engine.py
+++ b/pytd/query_engine.py
@@ -131,7 +131,6 @@ class QueryEngine(metaclass=abc.ABCMeta):
         """
         api_param_names = set(
             [
-                "type",
                 "db",
                 "result_url",
                 "priority",
@@ -140,6 +139,13 @@ class QueryEngine(metaclass=abc.ABCMeta):
                 "wait_callback",
             ]
         )
+
+        if "type" in kwargs:
+            raise RuntimeError(
+                "optional query parameter 'type' is unsupported. Issue query "
+                "from a proper QueryEngine instance: "
+                "{PrestoQueryEngine, HiveQueryEngine}."
+            )
 
         # update a clone of the original params
         cursor_kwargs = con._cursor_kwargs.copy()


### PR DESCRIPTION
because it is conflicted with `engine` argument. 

Dynamic change of query engine should be unsupported because we currently have separated `QueryEngine` implementation for each of Hive and Presto.

Updated docstring accordingly.