### PR TITLE
Bundle td-pyspark

### DIFF
--- a/appveyor/requirements.txt
+++ b/appveyor/requirements.txt
@@ -1,6 +1,7 @@
 presto-python-client>=0.6.0
 pandas
 td-client
+td-pyspark
 pyspark
 pyarrow
 pytest

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -21,6 +21,7 @@ API Reference
 
    reference
    pandas_td
+   pyspark
    dbapi
 
 Changelog

--- a/doc/pyspark.rst
+++ b/doc/pyspark.rst
@@ -1,0 +1,5 @@
+PySpark Integration
+~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: pytd.spark
+  :members:

--- a/pytd/client.py
+++ b/pytd/client.py
@@ -58,9 +58,8 @@ class Client(object):
                     "either argument 'apikey' or environment variable"
                     "'TD_API_KEY' should be set"
                 )
-            endpoint = endpoint or os.getenv(
-                "TD_API_SERVER", "https://api.treasuredata.com"
-            )
+            if endpoint is None:
+                endpoint = os.getenv("TD_API_SERVER", "https://api.treasuredata.com")
             default_engine = self._fetch_query_engine(
                 default_engine, apikey, endpoint, database, header
             )

--- a/pytd/spark.py
+++ b/pytd/spark.py
@@ -1,0 +1,89 @@
+import logging
+import os
+import re
+from urllib.error import HTTPError
+from urllib.request import urlopen
+
+TD_SPARK_BASE_URL = "https://s3.amazonaws.com/td-spark/{}"
+TD_SPARK_JAR_NAME = "td-spark-assembly_2.11-19.7.0.jar"
+TD_SPARK_DEFAULT_PATH = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), TD_SPARK_JAR_NAME
+)
+logger = logging.getLogger(__name__)
+
+
+def download_td_spark(download_url=None, destination=None):
+    if download_url is None:
+        download_url = TD_SPARK_BASE_URL.format(TD_SPARK_JAR_NAME)
+
+    if destination is None:
+        destination = TD_SPARK_DEFAULT_PATH
+
+    try:
+        response = urlopen(download_url)
+    except HTTPError:
+        raise RuntimeError("failed to access to the download URL: " + download_url)
+
+    logger.info("Downloading td-spark...")
+    try:
+        with open(destination, "w+b") as f:
+            f.write(response.read())
+    except Exception:
+        os.remove(destination)
+        raise
+    logger.info("Completed to download")
+
+    response.close()
+
+
+def fetch_td_spark(apikey, endpoint, td_spark_path, download_if_missing, spark_configs):
+    try:
+        from pyspark.conf import SparkConf
+        from pyspark.sql import SparkSession
+    except ImportError:
+        raise RuntimeError("PySpark is not installed")
+
+    conf = (
+        SparkConf()
+        .setMaster("local[*]")
+        .set("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+        .set("spark.sql.execution.arrow.enabled", "true")
+    )
+    conf.set("spark.td.apikey", apikey)
+
+    if td_spark_path is None:
+        td_spark_path = TD_SPARK_DEFAULT_PATH
+
+    available = os.path.exists(td_spark_path)
+
+    if not available and download_if_missing:
+        download_td_spark(destination=td_spark_path)
+    elif not available:
+        raise IOError("td-spark is not found and `download_if_missing` is False")
+
+    conf.set("spark.jars", td_spark_path)
+
+    plazma_api = os.getenv("TD_PLAZMA_API")
+    presto_api = os.getenv("TD_PRESTO_API")
+
+    if plazma_api and presto_api:
+        api_regex = re.compile(r"(?:https?://)?(api(?:-.+?)?)\.")
+        conf.set("spark.td.api.host", api_regex.sub("\\1.", endpoint).strip("/"))
+        conf.set("spark.td.plazma_api.host", plazma_api)
+        conf.set("spark.td.presto_api.host", presto_api)
+
+    site = "us"
+    if ".co.jp" in endpoint:
+        site = "jp"
+    if "eu01" in endpoint:
+        site = "eu01"
+    conf.set("spark.td.site", site)
+
+    if isinstance(spark_configs, dict):
+        for k, v in spark_configs.items():
+            conf.set(k, v)
+
+    try:
+        return SparkSession.builder.config(conf=conf).getOrCreate()
+    except Exception as e:
+        raise RuntimeError("failed to connect to td-spark: " + str(e))

--- a/pytd/spark.py
+++ b/pytd/spark.py
@@ -98,7 +98,8 @@ def fetch_td_spark_context(
             "either argument 'apikey' or environment variable"
             "'TD_API_KEY' should be set"
         )
-    endpoint = endpoint or os.getenv("TD_API_SERVER", "https://api.treasuredata.com")
+    if endpoint is None:
+        endpoint = os.getenv("TD_API_SERVER", "https://api.treasuredata.com")
 
     conf = (
         SparkConf()

--- a/pytd/spark.py
+++ b/pytd/spark.py
@@ -9,7 +9,7 @@ TD_SPARK_BASE_URL = "https://s3.amazonaws.com/td-spark/"
 logger = logging.getLogger(__name__)
 
 
-def download_td_spark(spark_binary_version="2.11", version="19.7.0", destination=None):
+def download_td_spark(spark_binary_version="2.11", version="latest", destination=None):
     td_spark_jar_name = "td-spark-assembly_{}-{}.jar".format(
         spark_binary_version, version
     )

--- a/pytd/spark.py
+++ b/pytd/spark.py
@@ -51,17 +51,24 @@ def download_td_spark(spark_binary_version="2.11", version="latest", destination
 
 
 def fetch_td_spark_context(
-    apikey, endpoint, td_spark_path=None, download_if_missing=True, spark_configs=None
+    apikey=None,
+    endpoint=None,
+    td_spark_path=None,
+    download_if_missing=True,
+    spark_configs=None,
 ):
     """Build TDSparkContext via td-pyspark.
 
     Parameters
     ----------
-    apikey : string
-        Treasure Data API key.
+    apikey : string, optional
+        Treasure Data API key. If not given, a value of environment variable
+        ``TD_API_KEY`` is used by default.
 
-    endpoint : string
-        Treasure Data API server.
+    endpoint : string, optional
+        Treasure Data API server. If not given, https://api.treasuredata.com is
+        used by default. List of available endpoints is:
+        https://support.treasuredata.com/hc/en-us/articles/360001474288-Sites-and-Endpoints
 
     td_spark_path : string, optional
         Path to td-spark-assembly_x.xx-x.x.x.jar. If not given, seek a path
@@ -84,6 +91,14 @@ def fetch_td_spark_context(
         from td_pyspark import TDSparkContextBuilder
     except ImportError:
         raise RuntimeError("td_pyspark is not installed")
+
+    apikey = apikey or os.environ.get("TD_API_KEY")
+    if apikey is None:
+        raise ValueError(
+            "either argument 'apikey' or environment variable"
+            "'TD_API_KEY' should be set"
+        )
+    endpoint = endpoint or os.getenv("TD_API_SERVER", "https://api.treasuredata.com")
 
     conf = (
         SparkConf()

--- a/pytd/spark.py
+++ b/pytd/spark.py
@@ -10,6 +10,19 @@ logger = logging.getLogger(__name__)
 
 
 def download_td_spark(spark_binary_version="2.11", version="latest", destination=None):
+    """Download a td-spark jar file from S3.
+
+    Parameters
+    ----------
+    spark_binary_version : string, default: '2.11'
+        Apache Spark binary version.
+
+    version : string, default: 'latest'
+        td-spark version.
+
+    destionation : string, optional
+        Where a downloaded jar file to be stored.
+    """
     td_spark_jar_name = "td-spark-assembly_{}-{}.jar".format(
         spark_binary_version, version
     )
@@ -38,8 +51,32 @@ def download_td_spark(spark_binary_version="2.11", version="latest", destination
 
 
 def fetch_td_spark_context(
-    apikey, endpoint, td_spark_path, download_if_missing, spark_configs
+    apikey, endpoint, td_spark_path=None, download_if_missing=True, spark_configs=None
 ):
+    """Build TDSparkContext via td-pyspark.
+
+    Parameters
+    ----------
+    apikey : string
+        Treasure Data API key.
+
+    endpoint : string
+        Treasure Data API server.
+
+    td_spark_path : string, optional
+        Path to td-spark-assembly_x.xx-x.x.x.jar. If not given, seek a path
+        ``TDSparkContextBuilder.default_jar_path()`` by default.
+
+    download_if_missing : boolean, default: True
+        Download td-spark if it does not exist at the time of initialization.
+
+    spark_configs : dict, optional
+        Additional Spark configurations to be set via ``SparkConf``'s ``set`` method.
+
+    Returns
+    -------
+    td_pyspark.TDSparkContext
+    """
     try:
         from pyspark.conf import SparkConf
         from pyspark.sql import SparkSession

--- a/pytd/tests/test_writer.py
+++ b/pytd/tests/test_writer.py
@@ -182,7 +182,7 @@ class SparkWriterTestCase(unittest.TestCase):
         self.writer = SparkWriter()
 
         td_spark = MagicMock()
-        td_spark._jsc.sc().isStopped.return_value = False
+        td_spark.spark._jsc.sc().isStopped.return_value = False
         self.writer.td_spark = td_spark
         self.writer.fetched_apikey = "1/XXX"
         self.writer.fetched_endpoint = "ENDPOINT"
@@ -193,8 +193,8 @@ class SparkWriterTestCase(unittest.TestCase):
 
     def test_write_dataframe(self):
         df = pd.DataFrame([[1, 2], [3, 4]])
-        self.writer.write_dataframe(df, self.table, "error")
-        self.assertTrue(self.writer.td_spark.createDataFrame.called)
+        self.writer.write_dataframe(df, self.table, "overwrite")
+        self.assertTrue(self.writer.td_spark.spark.createDataFrame.called)
 
     def test_write_dataframe_invalid_if_exists(self):
         with self.assertRaises(ValueError):
@@ -204,9 +204,9 @@ class SparkWriterTestCase(unittest.TestCase):
 
     def test_close(self):
         self.writer.close()
-        self.assertTrue(self.writer.td_spark.stop.called)
+        self.assertTrue(self.writer.td_spark.spark.stop.called)
 
-        self.writer.td_spark._jsc.sc().isStopped.return_value = True
+        self.writer.td_spark.spark._jsc.sc().isStopped.return_value = True
         self.assertTrue(self.writer.closed)
         with self.assertRaises(RuntimeError):
             self.writer.write_dataframe(

--- a/pytd/tests/test_writer.py
+++ b/pytd/tests/test_writer.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import numpy as np
 import pandas as pd
@@ -178,8 +178,7 @@ class BulkImportWriterTestCase(unittest.TestCase):
 
 
 class SparkWriterTestCase(unittest.TestCase):
-    @patch.object(SparkWriter, "_fetch_td_spark", return_value=MagicMock())
-    def setUp(self, _fetch_td_spark):
+    def setUp(self):
         self.writer = SparkWriter()
 
         td_spark = MagicMock()

--- a/pytd/writer.py
+++ b/pytd/writer.py
@@ -352,7 +352,7 @@ class SparkWriter(Writer):
     ----------
     td_spark_path : string, optional
         Path to td-spark-assembly_x.xx-x.x.x.jar. If not given, seek a path
-        ``__file__ + TD_SPARK_JAR_NAME`` by default.
+        ``TDSparkContextBuilder.default_jar_path()`` by default.
 
     download_if_missing : boolean, default: True
         Download td-spark if it does not exist at the time of initialization.

--- a/pytd/writer.py
+++ b/pytd/writer.py
@@ -5,7 +5,7 @@ import time
 
 import pandas as pd
 
-from .spark import fetch_td_spark
+from .spark import fetch_td_spark_context
 
 logger = logging.getLogger(__name__)
 
@@ -373,7 +373,7 @@ class SparkWriter(Writer):
 
     @property
     def closed(self):
-        return self.td_spark is not None and self.td_spark._jsc.sc().isStopped()
+        return self.td_spark is not None and self.td_spark.spark._jsc.sc().isStopped()
 
     def write_dataframe(self, dataframe, table, if_exists):
         """Write a given DataFrame to a Treasure Data table.
@@ -401,17 +401,28 @@ class SparkWriter(Writer):
         if self.closed:
             raise RuntimeError("this writer is already closed and no longer available")
 
-        if if_exists not in ("error", "overwrite", "append", "ignore"):
+        if if_exists == "error":
+            raise RuntimeError(
+                "target table '{}.{}' already exists".format(
+                    table.database, table.table
+                )
+            )
+        elif if_exists == "ignore":
+            return
+        elif if_exists == "append" or if_exists == "overwrite":
+            pass
+        else:
             raise ValueError("invalid valud for if_exists: {}".format(if_exists))
 
         if self.td_spark is None:
-            self.td_spark = fetch_td_spark(
+            self.td_spark = fetch_td_spark_context(
                 table.client.apikey,
                 table.client.endpoint,
                 self.td_spark_path,
                 self.download_if_missing,
                 self.spark_configs,
             )
+
             self.fetched_apikey, self.fetched_endpoint = (
                 table.client.apikey,
                 table.client.endpoint,
@@ -428,11 +439,13 @@ class SparkWriter(Writer):
         from py4j.protocol import Py4JJavaError
 
         _cast_dtypes(dataframe)
-        sdf = self.td_spark.createDataFrame(dataframe)
+        sdf = self.td_spark.spark.createDataFrame(dataframe)
         try:
-            sdf.write.mode(if_exists).format("com.treasuredata.spark").option(
-                "table", "{}.{}".format(table.database, table.table)
-            ).save()
+            destination = "{}.{}".format(table.database, table.table)
+            if if_exists == "append":
+                self.td_spark.insert_into(sdf, destination)
+            else:  # overwrite
+                self.td_spark.create_or_replace(sdf, destination)
         except Py4JJavaError as e:
             if "API_ACCESS_FAILURE" in str(e.java_exception):
                 raise PermissionError(
@@ -447,4 +460,4 @@ class SparkWriter(Writer):
         """Close a PySpark session connected to Treasure Data.
         """
         if self.td_spark is not None:
-            self.td_spark.stop()
+            self.td_spark.spark.stop()

--- a/pytd/writer.py
+++ b/pytd/writer.py
@@ -1,16 +1,12 @@
 import abc
 import logging
-import os
-import re
 import tempfile
 import time
-from urllib.error import HTTPError
-from urllib.request import urlopen
 
 import pandas as pd
 
-TD_SPARK_BASE_URL = "https://s3.amazonaws.com/td-spark/{}"
-TD_SPARK_JAR_NAME = "td-spark-assembly_2.11-19.7.0.jar"
+from .spark import fetch_td_spark
+
 logger = logging.getLogger(__name__)
 
 
@@ -409,7 +405,7 @@ class SparkWriter(Writer):
             raise ValueError("invalid valud for if_exists: {}".format(if_exists))
 
         if self.td_spark is None:
-            self.td_spark = self._fetch_td_spark(
+            self.td_spark = fetch_td_spark(
                 table.client.apikey,
                 table.client.endpoint,
                 self.td_spark_path,
@@ -452,77 +448,3 @@ class SparkWriter(Writer):
         """
         if self.td_spark is not None:
             self.td_spark.stop()
-
-    def _fetch_td_spark(
-        self, apikey, endpoint, td_spark_path, download_if_missing, spark_configs
-    ):
-        try:
-            from pyspark.conf import SparkConf
-            from pyspark.sql import SparkSession
-        except ImportError:
-            raise RuntimeError("PySpark is not installed")
-
-        conf = (
-            SparkConf()
-            .setMaster("local[*]")
-            .set("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
-            .set("spark.sql.execution.arrow.enabled", "true")
-        )
-        conf.set("spark.td.apikey", apikey)
-
-        if td_spark_path is None:
-            td_spark_path = os.path.join(
-                os.path.dirname(os.path.abspath(__file__)), TD_SPARK_JAR_NAME
-            )
-
-        available = os.path.exists(td_spark_path)
-
-        if not available and download_if_missing:
-            self._download_td_spark(td_spark_path)
-        elif not available:
-            raise IOError("td-spark is not found and `download_if_missing` is False")
-
-        conf.set("spark.jars", td_spark_path)
-
-        plazma_api = os.getenv("TD_PLAZMA_API")
-        presto_api = os.getenv("TD_PRESTO_API")
-
-        if plazma_api and presto_api:
-            api_regex = re.compile(r"(?:https?://)?(api(?:-.+?)?)\.")
-            conf.set("spark.td.api.host", api_regex.sub("\\1.", endpoint).strip("/"))
-            conf.set("spark.td.plazma_api.host", plazma_api)
-            conf.set("spark.td.presto_api.host", presto_api)
-
-        site = "us"
-        if ".co.jp" in endpoint:
-            site = "jp"
-        if "eu01" in endpoint:
-            site = "eu01"
-        conf.set("spark.td.site", site)
-
-        if isinstance(spark_configs, dict):
-            for k, v in spark_configs.items():
-                conf.set(k, v)
-
-        try:
-            return SparkSession.builder.config(conf=conf).getOrCreate()
-        except Exception as e:
-            raise RuntimeError("failed to connect to td-spark: " + str(e))
-
-    def _download_td_spark(self, destination):
-        download_url = TD_SPARK_BASE_URL.format(TD_SPARK_JAR_NAME)
-        try:
-            response = urlopen(download_url)
-        except HTTPError:
-            raise RuntimeError("failed to access to the download URL: " + download_url)
-
-        logger.info("Downloading td-spark...")
-        try:
-            with open(destination, "w+b") as f:
-                f.write(response.read())
-        except Exception:
-            os.remove(destination)
-            raise
-        logger.info("Completed to download")
-
-        response.close()

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ def setup_package():
             "pytz>=2018.5",
         ],
         extras_require={
-            "spark": ["pyspark>=2.4.0", "pyarrow>=0.11.0"],
+            "spark": ["td-pyspark>=19.7.0", "pyspark>=2.4.0", "pyarrow>=0.11.0"],
             "test": ["pytest"],
         },
     )


### PR DESCRIPTION
td-pyspark gives easier access to TD databases, tables, and Plazma APIs. Plus, since the package internally bundles td-spark JAR file, `SparkWriter` does not necessarily have to download the JAR file at the first time.