### PR TITLE
Make sure `endpoint` starts with 'https://' scheme

### DIFF
--- a/pytd/query_engine.py
+++ b/pytd/query_engine.py
@@ -30,6 +30,10 @@ class QueryEngine(metaclass=abc.ABCMeta):
     """
 
     def __init__(self, apikey, endpoint, database, header):
+        if not endpoint.startswith("https://"):
+            raise ValueError(
+                "Treasure Data API server `endpoint` must start with 'https://' scheme"
+            )
         self.apikey = apikey
         self.endpoint = endpoint
         self.database = database

--- a/pytd/query_engine.py
+++ b/pytd/query_engine.py
@@ -30,10 +30,8 @@ class QueryEngine(metaclass=abc.ABCMeta):
     """
 
     def __init__(self, apikey, endpoint, database, header):
-        if not endpoint.startswith("https://"):
-            raise ValueError(
-                "Treasure Data API server `endpoint` must start with 'https://' scheme"
-            )
+        if len(urlparse(endpoint).scheme) == 0:
+            endpoint = "https://{}".format(endpoint)
         self.apikey = apikey
         self.endpoint = endpoint
         self.database = database

--- a/pytd/tests/test_query_engine.py
+++ b/pytd/tests/test_query_engine.py
@@ -9,7 +9,7 @@ from pytd.version import __version__
 
 
 class QueryEngineEndpointSchemeTestCase(unittest.TestCase):
-    def test_presto_invalid_endpoint(self):
+    def test_presto_endpoint(self):
         presto = PrestoQueryEngine(
             "1/XXX", "api.treasuredata.com", "sample_datasets", True
         )
@@ -25,7 +25,7 @@ class QueryEngineEndpointSchemeTestCase(unittest.TestCase):
         )
         self.assertEqual(presto.endpoint, "https://api.treasuredata.com")
 
-    def test_hive_invalid_endpoint(self):
+    def test_hive_endpoint(self):
         hive = HiveQueryEngine("1/XXX", "api.treasuredata.com", "sample_datasets", True)
         self.assertEqual(hive.endpoint, "https://api.treasuredata.com")
 

--- a/pytd/tests/test_query_engine.py
+++ b/pytd/tests/test_query_engine.py
@@ -8,24 +8,26 @@ from pytd.query_engine import HiveQueryEngine, PrestoQueryEngine
 from pytd.version import __version__
 
 
-class QueryEngineInitializationFailureTestCase(unittest.TestCase):
+class QueryEngineEndpointSchemeTestCase(unittest.TestCase):
     def test_presto_invalid_endpoint(self):
-        with self.assertRaises(ValueError):
-            PrestoQueryEngine("1/XXX", "api.treasuredata.com", "sample_datasets", True)
+        presto = PrestoQueryEngine(
+            "1/XXX", "api.treasuredata.com", "sample_datasets", True
+        )
+        self.assertEqual(presto.endpoint, "https://api.treasuredata.com")
 
-        with self.assertRaises(ValueError):
-            PrestoQueryEngine(
-                "1/XXX", "http://api.treasuredata.com", "sample_datasets", True
-            )
+        presto = PrestoQueryEngine(
+            "1/XXX", "http://api.treasuredata.com", "sample_datasets", True
+        )
+        self.assertEqual(presto.endpoint, "http://api.treasuredata.com")
 
     def test_hive_invalid_endpoint(self):
-        with self.assertRaises(ValueError):
-            HiveQueryEngine("1/XXX", "api.treasuredata.com", "sample_datasets", True)
+        hive = HiveQueryEngine("1/XXX", "api.treasuredata.com", "sample_datasets", True)
+        self.assertEqual(hive.endpoint, "https://api.treasuredata.com")
 
-        with self.assertRaises(ValueError):
-            HiveQueryEngine(
-                "1/XXX", "http://api.treasuredata.com", "sample_datasets", True
-            )
+        hive = HiveQueryEngine(
+            "1/XXX", "http://api.treasuredata.com", "sample_datasets", True
+        )
+        self.assertEqual(hive.endpoint, "http://api.treasuredata.com")
 
 
 class PrestoQueryEngineTestCase(unittest.TestCase):

--- a/pytd/tests/test_query_engine.py
+++ b/pytd/tests/test_query_engine.py
@@ -8,6 +8,26 @@ from pytd.query_engine import HiveQueryEngine, PrestoQueryEngine
 from pytd.version import __version__
 
 
+class QueryEngineInitializationFailureTestCase(unittest.TestCase):
+    def test_presto_invalid_endpoint(self):
+        with self.assertRaises(ValueError):
+            PrestoQueryEngine("1/XXX", "api.treasuredata.com", "sample_datasets", True)
+
+        with self.assertRaises(ValueError):
+            PrestoQueryEngine(
+                "1/XXX", "http://api.treasuredata.com", "sample_datasets", True
+            )
+
+    def test_hive_invalid_endpoint(self):
+        with self.assertRaises(ValueError):
+            HiveQueryEngine("1/XXX", "api.treasuredata.com", "sample_datasets", True)
+
+        with self.assertRaises(ValueError):
+            HiveQueryEngine(
+                "1/XXX", "http://api.treasuredata.com", "sample_datasets", True
+            )
+
+
 class PrestoQueryEngineTestCase(unittest.TestCase):
     @patch.object(
         PrestoQueryEngine, "_connect", return_value=(MagicMock(), MagicMock())

--- a/pytd/tests/test_query_engine.py
+++ b/pytd/tests/test_query_engine.py
@@ -20,6 +20,11 @@ class QueryEngineEndpointSchemeTestCase(unittest.TestCase):
         )
         self.assertEqual(presto.endpoint, "http://api.treasuredata.com")
 
+        presto = PrestoQueryEngine(
+            "1/XXX", "https://api.treasuredata.com", "sample_datasets", True
+        )
+        self.assertEqual(presto.endpoint, "https://api.treasuredata.com")
+
     def test_hive_invalid_endpoint(self):
         hive = HiveQueryEngine("1/XXX", "api.treasuredata.com", "sample_datasets", True)
         self.assertEqual(hive.endpoint, "https://api.treasuredata.com")
@@ -28,6 +33,11 @@ class QueryEngineEndpointSchemeTestCase(unittest.TestCase):
             "1/XXX", "http://api.treasuredata.com", "sample_datasets", True
         )
         self.assertEqual(hive.endpoint, "http://api.treasuredata.com")
+
+        hive = HiveQueryEngine(
+            "1/XXX", "https://api.treasuredata.com", "sample_datasets", True
+        )
+        self.assertEqual(hive.endpoint, "https://api.treasuredata.com")
 
 
 class PrestoQueryEngineTestCase(unittest.TestCase):


### PR DESCRIPTION
URL scheme must be clearly speficied, and it has to be HTTPS.

Close #50 

--

Confirmed the issue:

```py
>>> import pytd
>>> client = pytd.Client(database='takuti', endpoint='api.treasuredata.com')

>>> client.query('select 1')  # presto-python-client
requests.exceptions.InvalidURL: Invalid URL 'https://:443/v1/statement': No host supplied

>>> client.query('select 1', engine='hive')  # td-client-python
{'data': [[1]], 'columns': ['_c0']}
```

The reason why td-client-python has no problem is likely to be in [`API#send_requests`](https://github.com/treasure-data/td-client-python/blob/5bd3c80422282ac8638a93d68879b89e11139da3/tdclient/api.py#L491-L506); the API instances send HTTP requests via `urllib3.PoolManager`, and it works without URL scheme:

```py
import urllib3
http = urllib3.PoolManager()
res = http.request(method='GET', url='api.treasuredata.com')
res.status  # => 200
```

This PR forces API endpoint to be specified with the HTTPS scheme:

```py
>>> import pytd.pandas_td as td
>>> connection = td.connect(endpoint="api.treasuredata.com")
ValueError: Treasure Data API server `endpoint` must be specified with 'https://' scheme

>>> import pytd
>>> client = pytd.Client(database='takuti', endpoint='api.treasuredata.com')
ValueError: Treasure Data API server `endpoint` must be specified with 'https://' scheme
```