### PR TITLE
Add msgpack option for BulkImportWriter

### DIFF
--- a/pytd/table.py
+++ b/pytd/table.py
@@ -114,7 +114,7 @@ class Table(object):
         if writer_from_string:
             writer = Writer.from_string(writer, **kwargs)
 
-        writer.write_dataframe(dataframe, self, if_exists)
+        writer.write_dataframe(dataframe, self, if_exists, **kwargs)
 
         if writer_from_string:
             writer.close()

--- a/pytd/tests/test_writer.py
+++ b/pytd/tests/test_writer.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import ANY, MagicMock
 
 import numpy as np
 import pandas as pd
@@ -124,6 +124,8 @@ class BulkImportWriterTestCase(unittest.TestCase):
         mock_bulk_import = MagicMock()
         mock_bulk_import.error_records = 1
         mock_bulk_import.valid_records = 2
+        mock_bulk_import.upload_part.return_value = MagicMock()
+        mock_bulk_import.upload_file.return_value = MagicMock()
 
         mock_api_client = MagicMock()
         mock_api_client.create_bulk_import.return_value = mock_bulk_import
@@ -161,6 +163,16 @@ class BulkImportWriterTestCase(unittest.TestCase):
         self.assertTrue(self.table.client.api_client.create_bulk_import.called)
         args, kwargs = self.table.client.api_client.create_bulk_import.call_args
         self.assertEqual(kwargs.get("params"), None)
+
+    def test_write_dataframe_msgpack(self):
+        self.writer.write_dataframe(
+            pd.DataFrame([[1, 2], [3, 4]]), self.table, "overwrite", fmt="msgpack"
+        )
+        api_client = self.table.client.api_client
+        self.assertTrue(api_client.create_bulk_import.called)
+        self.assertTrue(api_client.create_bulk_import().upload_part.called)
+        api_client.create_bulk_import().upload_part.assert_called_with("part", ANY, 62)
+        self.assertFalse(api_client.create_bulk_import().upload_file.called)
 
     def test_write_dataframe_invalid_if_exists(self):
         with self.assertRaises(ValueError):

--- a/pytd/writer.py
+++ b/pytd/writer.py
@@ -277,6 +277,11 @@ class BulkImportWriter(Writer):
             dataframe.to_csv(fp.name)
         elif fmt == "msgpack":
             fp = self._write_msgpack_stream(dataframe.to_dict(orient="records"), fp)
+        else:
+            raise ValueError(
+                "unsupported format '{}' for bulk import. "
+                "should be 'csv' or 'msgpack'".format(fmt)
+            )
 
         self._bulk_import(table, fp, if_exists, fmt)
 

--- a/pytd/writer.py
+++ b/pytd/writer.py
@@ -256,6 +256,12 @@ class BulkImportWriter(Writer):
 
         fmt : {'csv', 'msgpack'}, default: 'csv'
             Format for bulk_import.
+
+            - csv: Convert dataframe to temporary CSV file. Stable option but slower
+                than msgpack option because pytd saves dataframe as temporary CSV file,
+                then td-client converts it to msgpack.
+            - msgpack: Convert to temporary msgpack.gz file. Fast option but might be
+                unstable because of skipping ``tdclient.API._prepare_file()``
         """
         if self.closed:
             raise RuntimeError("this writer is already closed and no longer available")
@@ -298,7 +304,7 @@ class BulkImportWriter(Writer):
             - ignore: do nothing.
 
         fmt : {'csv', 'msgpack'}, default: 'csv'
-            File format for bulk import.
+            File format for bulk import. See also :func:`write_dataframe`
         """
         params = None
         if table.exist:

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ exclude =
     pytd/pandas_td/ipython.py
 
 [isort]
-known_third_party = IPython,nox,numpy,pandas,pkg_resources,prestodb,pytz,tdclient
+known_third_party = IPython,msgpack,nox,numpy,pandas,pkg_resources,prestodb,pytz,tdclient
 line_length=88
 multi_line_output=3
 include_trailing_comma=True


### PR DESCRIPTION
Introduce "msgpack" option for `BulkImportWriter.write_dataframe()` to increase performance.

Currently, pytd uses CSV for BulkImportWriter, but it needs to convert DataFrame to CSV and then tdclient converts it into msgpack.

"msgpack" option allows us to convert DataFrame to msgpack.gz and upload directly.

Sample usage:

```py
In [1]: import pandas as pd

In [2]: import pytd, random

In [3]: df = pd.DataFrame(data={'col1': [random.random() for _ in range(100000)]})

In [4]: client = pytd.Client()

In [9]: client.load_table_from_dataframe(df, "aki_test.foo", if_exists="overwrite", fmt="msgpack")
```

This reduces roughly 23% execution time for 100000-row records.

| format | execution time|
|---:|----:|
|csv|1min 25s ± 912 ms per loop (mean ± std. dev. of 2 runs, 4 loops each)|
|msgpack|1min 7s ± 1.73 s per loop (mean ± std. dev. of 2 runs, 4 loops each)|

See detail for profiling code (memory option was eventually removed):
https://gist.github.com/chezou/c6398d640af042772f3b343a5ff78743

Note that currently, we don't have this option for `pandas_td.to_td()` yet because I think it is an experimental feature.