### PR TITLE
Implement keep_list option to BulkImportWriter

### DIFF
--- a/pytd/tests/test_writer.py
+++ b/pytd/tests/test_writer.py
@@ -26,7 +26,11 @@ class WriterTestCase(unittest.TestCase):
                 "F": False,
                 "G": pd.Series([1] * 3, dtype="int8"),
                 "H": [[0, None, 2], [1, 2, 3], [2, 3, 4]],
-                "I": [[0, np.nan, 2], [1, 2, 3], [2, 3, 4]],
+                "I": [
+                    np.array([0, np.nan, 2]),
+                    np.array([1, 2, 3]),
+                    np.array([2, 3, 4]),
+                ],
             }
         )
 
@@ -59,7 +63,8 @@ class WriterTestCase(unittest.TestCase):
         self.assertTrue(isinstance(self.dft["H"].iloc[0][2], int))
         # numpy.ndarray containing numpy.nan will be converted as float type
         self.assertTrue(isinstance(self.dft["I"].iloc[0][2], float))
-        self.assertTrue(np.isnan(self.dft["I"].iloc[0][1]))
+        self.assertTrue(isinstance(self.dft["I"].iloc[1][2], int))
+        self.assertTrue(self.dft["I"].iloc[0][1] is None)
 
 
 class InsertIntoWriterTestCase(unittest.TestCase):

--- a/pytd/tests/test_writer.py
+++ b/pytd/tests/test_writer.py
@@ -31,6 +31,7 @@ class WriterTestCase(unittest.TestCase):
                     np.array([1, 2, 3]),
                     np.array([2, 3, 4]),
                 ],
+                "J": [np.array([0, np.nan, 2]), [1, 2, 3], [3, 4, 5]],
             }
         )
 
@@ -58,8 +59,9 @@ class WriterTestCase(unittest.TestCase):
         self.assertEqual(
             dtypes, set([np.dtype("int"), np.dtype("float"), np.dtype("O")])
         )
-        self.assertTrue(isinstance(self.dft["H"].iloc[0], list))
-        self.assertTrue(isinstance(self.dft["I"].iloc[0], list))
+        self.assertTrue(self.dft["H"].apply(lambda x: isinstance(x, list)).all())
+        self.assertTrue(self.dft["I"].apply(lambda x: isinstance(x, list)).all())
+        self.assertTrue(self.dft["J"].apply(lambda x: isinstance(x, list)).all())
         self.assertTrue(isinstance(self.dft["H"].iloc[0][2], int))
         # numpy.ndarray containing numpy.nan will be converted as float type
         self.assertTrue(isinstance(self.dft["I"].iloc[0][2], float))

--- a/pytd/tests/test_writer.py
+++ b/pytd/tests/test_writer.py
@@ -25,7 +25,8 @@ class WriterTestCase(unittest.TestCase):
                 "E": pd.Series([1.0] * 3).astype("float32"),
                 "F": False,
                 "G": pd.Series([1] * 3, dtype="int8"),
-                "H": [[0, 1, 2], [1, 2, 3], [2, 3, 4]],
+                "H": [[0, None, 2], [1, 2, 3], [2, 3, 4]],
+                "I": [[0, np.nan, 2], [1, 2, 3], [2, 3, 4]],
             }
         )
 
@@ -36,6 +37,8 @@ class WriterTestCase(unittest.TestCase):
             dtypes, set([np.dtype("int"), np.dtype("float"), np.dtype("O")])
         )
         self.assertEqual(dft["F"][0], "false")
+        self.assertTrue(isinstance(dft["H"][1], str))
+        self.assertEqual(dft["H"][1], "[1, 2, 3]")
 
     def test_cast_dtypes_inplace(self):
         _cast_dtypes(self.dft)
@@ -44,6 +47,19 @@ class WriterTestCase(unittest.TestCase):
             dtypes, set([np.dtype("int"), np.dtype("float"), np.dtype("O")])
         )
         self.assertEqual(self.dft["F"][0], "false")
+
+    def test_cast_dtypes_keep_list(self):
+        _cast_dtypes(self.dft, keep_list=True)
+        dtypes = set(self.dft.dtypes)
+        self.assertEqual(
+            dtypes, set([np.dtype("int"), np.dtype("float"), np.dtype("O")])
+        )
+        self.assertTrue(isinstance(self.dft["H"].iloc[0], list))
+        self.assertTrue(isinstance(self.dft["I"].iloc[0], list))
+        self.assertTrue(isinstance(self.dft["H"].iloc[0][2], int))
+        # numpy.ndarray containing numpy.nan will be converted as float type
+        self.assertTrue(isinstance(self.dft["I"].iloc[0][2], float))
+        self.assertTrue(np.isnan(self.dft["I"].iloc[0][1]))
 
 
 class InsertIntoWriterTestCase(unittest.TestCase):

--- a/pytd/writer.py
+++ b/pytd/writer.py
@@ -318,7 +318,7 @@ class BulkImportWriter(Writer):
 
             Note that ``numpy.nan`` will be converted as a string value as ``"NaN"``.
             Also, numpy converts integer array including ``numpy.nan`` into float array because
-            ``np.nan`` is a Floating Point Special Value. See also:
+            ``numpy.nan`` is a Floating Point Special Value. See also:
             https://docs.scipy.org/doc/numpy-1.13.0/user/misc.html#ieee-754-floating-point-special-values
 
             Or, you can use :func:`Client.load_table_from_dataframe` function as well.

--- a/pytd/writer.py
+++ b/pytd/writer.py
@@ -317,7 +317,7 @@ class BulkImportWriter(Writer):
             ... )
 
             Note that ``numpy.nan`` will be converted as a string value as ``"NaN"``.
-            Also, numpy converts integer array including np.nan into float array because
+            Also, numpy converts integer array including ``numpy.nan`` into float array because
             ``np.nan`` is a Floating Point Special Value. See also:
             https://docs.scipy.org/doc/numpy-1.13.0/user/misc.html#ieee-754-floating-point-special-values
 

--- a/pytd/writer.py
+++ b/pytd/writer.py
@@ -298,7 +298,7 @@ class BulkImportWriter(Writer):
             ...     {
             ...         "a": [[1, 2, 3], [2, 3, 4]],
             ...         "b": [[0, None, 2], [2, 3, 4]],
-            ...         "c": np.array([1, np.nan, 3], np.array([2, 3, 4]))
+            ...         "c": [np.array([1, np.nan, 3]), [2, 3, 4]]
             ...     }
             ... )
             >>> client = pytd.Client()


### PR DESCRIPTION
Add an option for BulkImportWriter.write_dataframe to keep list column as is.
It enables to create array type columns to Treasure Data.
Since InsertIntoWriter and SparkWriter have a difficulty to handle an array
properly, we add keep_list option only for BulkImportWriter at this
moment.

Related issue: #28 