### PR TITLE
Fix documentation error in contributing guide

### DIFF
--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -53,7 +53,7 @@ Documenting
 
 .. code:: sh
 
-   pip install -r doc/requirements.txt
+   pip install .[doc]
 
 Edit contents in ``doc/``:
 


### PR DESCRIPTION
Requirements for documenting had been moved to `setup.py`:
b3856315aeed2e50f2de369b355ae85be2262bca