### PR TITLE
Retain query executed result

### DIFF
--- a/pytd/client.py
+++ b/pytd/client.py
@@ -44,6 +44,31 @@ class Client(object):
     ----------
     api_client : :class:`tdclient.Client`
         Connection to Treasure Data.
+
+    query_executed : str or :class:`prestodb.client.PrestoResult`, default: `None`
+        Query execution result returned from DB-API Cursor object.
+
+        Examples
+        ---------
+
+        Presto query executed via ``prestodb`` returns ``PrestoResult`` object:
+
+        >>> import pytd
+        >>> client = pytd.Client()
+        >>> client.query_executed
+        >>> client.query('select 1')
+        >>> client.query_executed
+        <prestodb.client.PrestoResult object at 0x10b9826a0>
+
+        Meanwhile, ``tdclient`` runs a job on Treasure Data, and Cursor returns
+        its job id:
+
+        >>> client.query('select 1', priority=0)
+        >>> client.query_executed
+        '669563342'
+
+        Note that the optional argument ``priority`` forces the client to query
+        via tdclient.
     """
 
     def __init__(

--- a/pytd/client.py
+++ b/pytd/client.py
@@ -77,6 +77,7 @@ class Client(object):
         self.database = database
 
         self.default_engine = default_engine
+        self.query_executed = None
 
         self.api_client = tdclient.Client(
             apikey=apikey,
@@ -143,6 +144,9 @@ class Client(object):
     def query(self, query, engine=None, **kwargs):
         """Run query and get results.
 
+        Executed result stored in ``QueryEngine`` is retained in
+        ``self.query_executed``.
+
         Parameters
         ----------
         query : str
@@ -182,6 +186,7 @@ class Client(object):
             'columns'
                 List of column names.
         """
+        self.query_executed = None
         if isinstance(engine, QueryEngine):
             pass  # use the given QueryEngine instance
         elif isinstance(engine, str):
@@ -203,7 +208,9 @@ class Client(object):
         else:
             engine = self.default_engine
         header = engine.create_header("Client#query")
-        return engine.execute(header + query, **kwargs)
+        res = engine.execute(header + query, **kwargs)
+        self.query_executed = engine.executed
+        return res
 
     def get_table(self, database, table):
         """Create a pytd table control instance.

--- a/pytd/query_engine.py
+++ b/pytd/query_engine.py
@@ -36,6 +36,7 @@ class QueryEngine(metaclass=abc.ABCMeta):
         self.endpoint = endpoint
         self.database = database
         self.header = header
+        self.executed = None
 
     @property
     def user_agent(self):
@@ -45,6 +46,9 @@ class QueryEngine(metaclass=abc.ABCMeta):
 
     def execute(self, query, **kwargs):
         """Execute a given SQL statement and return results.
+
+        Executed result returned by Cursor object is stored in
+        ``self.executed``.
 
         Parameters
         ----------
@@ -80,7 +84,7 @@ class QueryEngine(metaclass=abc.ABCMeta):
                 List of column names.
         """
         cur = self.cursor(**kwargs)
-        cur.execute(query)
+        self.executed = cur.execute(query)
         rows = cur.fetchall()
         columns = [desc[0] for desc in cur.description]
         return {"data": rows, "columns": columns}

--- a/pytd/tests/test_client.py
+++ b/pytd/tests/test_client.py
@@ -19,6 +19,7 @@ class ClientTest(unittest.TestCase):
         self.assertEqual(self.client.database, "sample_datasets")
 
         self.assertTrue(fetch_query_engine.called)
+        self.assertEqual(self.client.query_executed, None)
         self.client.default_engine = MagicMock()
         self.client.api_client = MagicMock()
 

--- a/pytd/tests/test_query_engine.py
+++ b/pytd/tests/test_query_engine.py
@@ -49,6 +49,7 @@ class PrestoQueryEngineTestCase(unittest.TestCase):
             "1/XXX", "https://api.treasuredata.com/", "sample_datasets", True
         )
         self.assertTrue(connect.called)
+        self.assertEqual(self.presto.executed, None)
 
     def test_user_agent(self):
         ua = self.presto.user_agent
@@ -105,6 +106,7 @@ class HiveQueryEngineTestCase(unittest.TestCase):
             "1/XXX", "https://api.treasuredata.com/", "sample_datasets", True
         )
         self.assertTrue(connect.called)
+        self.assertEqual(self.hive.executed, None)
 
     def test_user_agent(self):
         hive_no_header = HiveQueryEngine(


### PR DESCRIPTION
`{tdclient,prestodb}.Cursor.execute` returns a resulting object (i.e., `prestodb` returns `PrestoResult`, `tdclient` returns executed job id). It would be useful for users to dig deep into the execution result, so this PR lets `Client` and `QueryEngine` to retain the objects.

This PR resolves #62.

```python
>>> import pytd
>>> client = pytd.Client()
>>> client.query('select 1')
{'data': [[1]], 'columns': ['_col0']}
>>> client.query_executed
<prestodb.client.PrestoResult object at 0x10b9826a0>
>>> client.query('select 1', priority=0)  # td-client
returning `tdclient.cursor.Cursor`. This cursor, `Cursor#fetchone` in particular, might behave different from your expectation, because it actually executes a job on Treasure Data and fetches all records at once from the job result.
{'data': [[1]], 'columns': ['_col0']}
>>> client.query_executed
'669563342'
```