### PR TITLE
Support null value for str and bool

### DIFF
--- a/pytd/writer.py
+++ b/pytd/writer.py
@@ -28,6 +28,14 @@ def _is_0d_nan(x):
     return _is_0d_ary(x) and x.dtype.kind == "f" and np.isnan(x)
 
 
+def _isnull(x):
+    return x is None or _is_np_nan(x)
+
+
+def _isinstance_or_null(x, t):
+    return _isnull(x) or isinstance(x, t)
+
+
 def _to_list(ary):
     # Return None if None, np.nan, or np.nan in 0-d array given
     if ary is None or _is_np_nan(ary) or _is_0d_nan(ary):
@@ -47,14 +55,6 @@ def _to_list(ary):
     elif kind == "O":
         _ary = np.array([None if _is_np_nan(x) else x for x in _ary])
     return _ary.tolist()
-
-
-def _isnull(x):
-    return x is None or x is np.nan
-
-
-def _isinstance_or_null(x, t):
-    return _isnull(x) or isinstance(x, t)
 
 
 def _convert_nullable_str(x, t, lower=False):


### PR DESCRIPTION
This PR makes null value writable for string and bool types.

```py
In [1]: import pytd

In [3]: import pandas as pd

In [4]: df = pd.DataFrame(data=[{'a':"A",'b':"B"}, {'a':"C",'b':"D",'c':"E"}])

In [5]: client = pytd.Client()

In [6]: client.load_table_from_dataframe(df, "aki.test_bi_str", "bulk_import", if_exists="overwrite")
uploading data converted into a csv file
performing a bulk import job
[job id 688757407] imported 2 records.

In [7]: client.query("select * from aki.test_bi_str")
Out[7]:
{'data': [['A', 'B', None, 1582885334], ['C', 'D', 'E', 1582885334]],
 'columns': ['a', 'b', 'c', 'time']}

In [8]: client.load_table_from_dataframe(df, "aki.test_bi_spark", "spark", if_exists="overwrite")

In [10]: client.query("select * from aki.test_bi_spark")
Out[10]:
{'data': [['A', 'B', None, 1582885586], ['C', 'D', 'E', 1582885586]],
 'columns': ['a', 'b', 'c', 'time']}
```

Fix #67 