### PR TITLE
Update minimum required pandas version to 0.24.0

### DIFF
--- a/pytd/writer.py
+++ b/pytd/writer.py
@@ -15,6 +15,17 @@ from .spark import fetch_td_spark_context
 
 logger = logging.getLogger(__name__)
 
+if pd.__version__ >= "1.0.0":
+    logger.warning(
+        "You are using pandas 1.0.0 or later, but pytd is not fully tested on "
+        "the major version. Since the version has introduced some "
+        "experimental, backward-incompatible features, there might be a "
+        "chance of unexpected runtime failure when you handle a DataFrame "
+        "containing null or array. See pandas official documentation for more "
+        "information: "
+        "https://pandas.pydata.org/pandas-docs/version/1.0.0/whatsnew/v1.0.0.html"
+    )
+
 
 def _is_np_nan(x):
     return isinstance(x, float) and np.isnan(x)
@@ -79,17 +90,6 @@ def _cast_dtypes(dataframe, inplace=True, keep_list=False):
     U  Unicode
     V  void
     """
-    if pd.__version__ >= "1.0.0":
-        logger.warning(
-            "You are using pandas 1.0.0 or later, but pytd is not fully tested on "
-            "the major version. Since the version has introduced some "
-            "experimental, backward-incompatible features, there might be a "
-            "chance of unexpected runtime failure when you write a DataFrame "
-            "containing null or array, See pandas official documentation for more "
-            "information: "
-            "https://pandas.pydata.org/pandas-docs/version/1.0.0/whatsnew/v1.0.0.html"
-        )
-
     df = dataframe if inplace else dataframe.copy()
 
     for column, kind in dataframe.dtypes.apply(lambda dtype: dtype.kind).iteritems():

--- a/pytd/writer.py
+++ b/pytd/writer.py
@@ -79,6 +79,17 @@ def _cast_dtypes(dataframe, inplace=True, keep_list=False):
     U  Unicode
     V  void
     """
+    if pd.__version__ >= "1.0.0":
+        logger.warning(
+            "You are using pandas 1.0.0 or later, but pytd is not fully tested on "
+            "the major version. Since the version has introduced some "
+            "experimental, backward-incompatible features, there might be a "
+            "chance of unexpected runtime failure when you write a DataFrame "
+            "containing null or array, See pandas official documentation for more "
+            "information: "
+            "https://pandas.pydata.org/pandas-docs/version/1.0.0/whatsnew/v1.0.0.html"
+        )
+
     df = dataframe if inplace else dataframe.copy()
 
     for column, kind in dataframe.dtypes.apply(lambda dtype: dtype.kind).iteritems():

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ def setup_package():
         install_requires=[
             "urllib3<1.25,>=1.21.1",
             "presto-python-client>=0.6.0",
-            "pandas>=0.22.0",
+            "pandas>=0.24.0",
             "td-client>=1.1.0",
             "pytz>=2018.5",
         ],


### PR DESCRIPTION
Since `pandas.array` is available pandas 0.24.0 or later, pandas 0.22.0 causes unit test failure:

https://github.com/treasure-data/pytd/blob/a109ccd1141dcef6fb7fd5534165e5bd7cab15c2/pytd/tests/test_writer.py#L114-L126

While the change impacts only on test cases, I believe it should be safe to make this subtle update of the dependent package. Or, we can alternatively modify the test cases and stop using `pandas.array`.

@chezou Let me know if there is any concern.