### PR TITLE
Add Writer comparison chart to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -99,6 +99,22 @@ data to Treasure Data:
    -  Local customized Spark instance directly writes ``DataFrame`` to
       Treasure Data’s primary storage system.
 
+Characteristics of each of these methods can be summarized as follows:
+
++-----------------------------------+------------------+------------------+-----------+
+|                                   | ``bulk_import``  | ``insert_into``  | ``spark`` |
++===================================+==================+==================+===========+
+| Scalable against data volume      |        ✓         |                  |     ✓     |
++-----------------------------------+------------------+------------------+-----------+
+| Write performance for larger data |                  |                  |     ✓     |
++-----------------------------------+------------------+------------------+-----------+
+| Memory efficient                  |        ✓         |        ✓         |           |
++-----------------------------------+------------------+------------------+-----------+
+| Disk efficient                    |                  |        ✓         |           |
++-----------------------------------+------------------+------------------+-----------+
+| Minimal package dependency        |        ✓         |        ✓         |           |
++-----------------------------------+------------------+------------------+-----------+
+
 Enabling Spark Writer
 ^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
This PR copies the chart in [Google Colab example](https://colab.research.google.com/drive/1ps_ChU-H2FvkeNlj1e1fcOebCt4ryN11#scrollTo=VRxnXgdW5ADo) to pytd official doc.