### PR TITLE
fix: ensure None with Int64 column for SparkWriter

### DIFF
--- a/pytd/writer.py
+++ b/pytd/writer.py
@@ -625,6 +625,9 @@ class SparkWriter(Writer):
         from py4j.protocol import Py4JJavaError
 
         _cast_dtypes(dataframe)
+        # Replace np.nan to None to avoid Int64 conversion issue
+        if dataframe.isnull().any().any():
+            dataframe.replace({np.nan: None}, inplace=True)
         sdf = self.td_spark.spark.createDataFrame(dataframe)
         try:
             destination = "{}.{}".format(table.database, table.table)


### PR DESCRIPTION
This change follows up #68.

Since PySpark's spark.createDataFrame() doesn't allow nullable columns,
i.e., columns with np.nan, except for float dtype, we need to ensure
None instead of numpy.nan for Int64 column as well as bool, str dtypes.

Without this modification, spark.createDataFrame raises TypeError like:
```
TypeError: field c: Can not merge type <class 'pyspark.sql.types.DoubleType'> and <class 'pyspark.sql.types.LongType'>
```
with Int64 dtype including np.nan values.