### PR TITLE
Support pandas.NA by converting into None

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -12,7 +12,7 @@ def lint(session):
 
 
 @nox.session
-@nox.parametrize("pandas", ["0.25", "1.0"])
+@nox.parametrize("pandas", ["0.24.2", "0.25.3", "1.0.1"])
 def tests(session, pandas):
     session.install(".[test,spark]")
     session.install("pandas=={}".format(pandas))

--- a/noxfile.py
+++ b/noxfile.py
@@ -12,6 +12,8 @@ def lint(session):
 
 
 @nox.session
-def tests(session):
+@nox.parametrize("pandas", ["0.25", "1.0"])
+def tests(session, pandas):
     session.install(".[test,spark]")
+    session.install("pandas=={}".format(pandas))
     session.run("pytest", "-v")

--- a/pytd/tests/test_writer.py
+++ b/pytd/tests/test_writer.py
@@ -88,7 +88,9 @@ class WriterTestCase(unittest.TestCase):
         # This is for consistency of _get_schema
         self.assertTrue(pd.isna(dft["O"][2]))
 
-    @unittest.skipIf(pd.__version__ < "1.0.0", "not supported in this pandas version")
+    @unittest.skipIf(
+        pd.__version__ < "1.0.0", "pd.NA is not supported in this pandas version"
+    )
     def test_cast_dtypes_nullable(self):
         dft = pd.DataFrame(
             {
@@ -284,7 +286,9 @@ class BulkImportWriterTestCase(unittest.TestCase):
             self.writer._write_msgpack_stream.call_args[0][0], expected_list
         )
 
-    @unittest.skipIf(pd.__version__ < "1.0.0", "not supported in this pandas version")
+    @unittest.skipIf(
+        pd.__version__ < "1.0.0", "pd.NA not supported in this pandas version"
+    )
     def test_write_dataframe_msgpack_with_string_na(self):
         df = pd.DataFrame(
             data=[{"a": "foo", "b": "bar"}, {"a": "buzz", "b": "buzz", "c": "alice"}],
@@ -302,7 +306,9 @@ class BulkImportWriterTestCase(unittest.TestCase):
             self.writer._write_msgpack_stream.call_args[0][0], expected_list
         )
 
-    @unittest.skipIf(pd.__version__ < "1.0.0", "not supported in this pandas version")
+    @unittest.skipIf(
+        pd.__version__ < "1.0.0", "pd.NA not supported in this pandas version"
+    )
     def test_write_dataframe_msgpack_with_boolean_na(self):
         df = pd.DataFrame(
             data=[{"a": True, "b": False}, {"a": False, "b": True, "c": True}],
@@ -373,7 +379,9 @@ class SparkWriterTestCase(unittest.TestCase):
             self.writer.td_spark.spark.createDataFrame.call_args[0][0], expected_df
         )
 
-    @unittest.skipIf(pd.__version__ < "1.0.0", "not supported in this pandas version")
+    @unittest.skipIf(
+        pd.__version__ < "1.0.0", "pd.NA is not supported in this pandas version"
+    )
     def test_write_dataframe_with_string_na(self):
         df = pd.DataFrame(
             data=[{"a": "foo", "b": "bar"}, {"a": "buzz", "b": "buzz", "c": "alice"}],
@@ -386,7 +394,9 @@ class SparkWriterTestCase(unittest.TestCase):
             self.writer.td_spark.spark.createDataFrame.call_args[0][0], expected_df
         )
 
-    @unittest.skipIf(pd.__version__ < "1.0.0", "not supported in this pandas version")
+    @unittest.skipIf(
+        pd.__version__ < "1.0.0", "pd.NA is not supported in this pandas version"
+    )
     def test_write_dataframe_with_boolean_na(self):
         df = pd.DataFrame(
             data=[{"a": True, "b": False}, {"a": False, "b": True, "c": True}],

--- a/pytd/tests/test_writer.py
+++ b/pytd/tests/test_writer.py
@@ -102,8 +102,8 @@ class WriterTestCase(unittest.TestCase):
         dft = _cast_dtypes(dft, inplace=False)
         dtypes = set(dft.dtypes)
         self.assertEqual(dtypes, set([np.dtype("O")]))
-        self.assertTrue(dft["P"][2] is None)
-        self.assertTrue(dft["Q"][2] is None)
+        self.assertIsNone(dft["P"][2])
+        self.assertIsNone(dft["Q"][2])
 
     def test_cast_dtypes_inplace(self):
         _cast_dtypes(self.dft)
@@ -128,7 +128,7 @@ class WriterTestCase(unittest.TestCase):
         # numpy.ndarray containing numpy.nan will be converted as float type
         self.assertTrue(isinstance(self.dft["I"].iloc[0][2], float))
         self.assertTrue(isinstance(self.dft["I"].iloc[1][2], int))
-        self.assertTrue(self.dft["I"].iloc[0][1] is None)
+        self.assertIsNone(self.dft["I"].iloc[0][1])
 
 
 class InsertIntoWriterTestCase(unittest.TestCase):

--- a/pytd/writer.py
+++ b/pytd/writer.py
@@ -99,7 +99,7 @@ def _cast_dtypes(dataframe, inplace=True, keep_list=False):
             t = "Int64" if df[column].isnull().any() else "int64"
         elif kind == "f":
             t = float
-        elif kind == "O":
+        elif kind in ("b", "O"):
             t = object
             if df[column].apply(_isinstance_or_null, args=((list, np.ndarray),)).all():
                 if keep_list:
@@ -109,6 +109,9 @@ def _cast_dtypes(dataframe, inplace=True, keep_list=False):
                         _convert_nullable_str, args=((list, np.ndarray),)
                     )
             elif df[column].apply(_isinstance_or_null, args=(bool,)).all():
+                # Bulk Import API internally handles boolean string as a boolean type,
+                # and hence "True" ("False") will be stored as "true" ("false"). Align
+                # to lower case here.
                 df[column] = df[column].apply(
                     _convert_nullable_str, args=(bool,), lower=True
                 )
@@ -116,14 +119,6 @@ def _cast_dtypes(dataframe, inplace=True, keep_list=False):
                 df[column] = df[column].apply(_convert_nullable_str, args=(str,))
             else:
                 t = str
-        elif kind == "b":
-            # Bulk Import API internally handles boolean string as a boolean type,
-            # and hence "True" ("False") will be stored as "true" ("false"). Align
-            # to lower case here.
-            t = object
-            df[column] = df[column].apply(
-                _convert_nullable_str, args=(bool,), lower=True
-            )
         df[column] = df[column].astype(t)
 
     if not inplace:


### PR DESCRIPTION
Resolve #64 for BulkImport with msgpack and SparkWriter. This patch
supports both pandas 0.25 and 1.0+.

Note that even if you use Int64 column, BulkImport API will treat it as
varchar column on Treasure Data.