### PR TITLE
Support `engine_version` parameter for query API

### DIFF
--- a/pytd/client.py
+++ b/pytd/client.py
@@ -201,6 +201,9 @@ class Client(object):
             - ``retry_limit`` (int): max number of automatic retries
             - ``wait_interval`` (int): sleep interval until job finish
             - ``wait_callback`` (function): called every interval against job itself
+            - ``engine_version`` (str): run query with Hive 2 if this parameter
+              is set to ``"experimental"`` and ``engine`` denotes Hive.
+              https://support.treasuredata.com/hc/en-us/articles/360027259074-How-to-use-Hive-2
 
         Returns
         -------

--- a/pytd/pandas_td/__init__.py
+++ b/pytd/pandas_td/__init__.py
@@ -167,6 +167,9 @@ def read_td_query(
         - ``retry_limit`` (int): max number of automatic retries
         - ``wait_interval`` (int): sleep interval until job finish
         - ``wait_callback`` (function): called every interval against job itself
+        - ``engine_version`` (str): run query with Hive 2 if this parameter is
+          set to ``"experimental"`` in ``HiveQueryEngine``.
+          https://support.treasuredata.com/hc/en-us/articles/360027259074-How-to-use-Hive-2
 
     Returns
     -------

--- a/pytd/query_engine.py
+++ b/pytd/query_engine.py
@@ -73,6 +73,9 @@ class QueryEngine(metaclass=abc.ABCMeta):
             - ``retry_limit`` (int): max number of automatic retries
             - ``wait_interval`` (int): sleep interval until job finish
             - ``wait_callback`` (function): called every interval against job itself
+            - ``engine_version`` (str): run query with Hive 2 if this parameter
+              is set to ``"experimental"`` in ``HiveQueryEngine``.
+              https://support.treasuredata.com/hc/en-us/articles/360027259074-How-to-use-Hive-2
 
         Returns
         -------
@@ -168,6 +171,9 @@ class QueryEngine(metaclass=abc.ABCMeta):
             - ``retry_limit`` (int): max number of automatic retries
             - ``wait_interval`` (int): sleep interval until job finish
             - ``wait_callback`` (function): called every interval against job itself
+            - ``engine_version`` (str): run query with Hive 2 if this parameter
+              is set to ``"experimental"`` in ``HiveQueryEngine``.
+              https://support.treasuredata.com/hc/en-us/articles/360027259074-How-to-use-Hive-2
 
         Returns
         -------
@@ -181,6 +187,7 @@ class QueryEngine(metaclass=abc.ABCMeta):
                 "retry_limit",
                 "wait_interval",
                 "wait_callback",
+                "engine_version",
             ]
         )
 
@@ -372,6 +379,9 @@ class HiveQueryEngine(QueryEngine):
             - ``retry_limit`` (int): max number of automatic retries
             - ``wait_interval`` (int): sleep interval until job finish
             - ``wait_callback`` (function): called every interval against job itself
+            - ``engine_version`` (str): run query with Hive 2 if this parameter
+              is set to ``"experimental"``.
+              https://support.treasuredata.com/hc/en-us/articles/360027259074-How-to-use-Hive-2
 
         Returns
         -------


### PR DESCRIPTION
The parameter enables users to execute a query with Hive 2:
https://support.treasuredata.com/hc/en-us/articles/360027259074-How-to-use-Hive-2