### PR TITLE
Add `force_tdclient` option for deterministically using `tdclient` rather than `prestodb`

### DIFF
--- a/pytd/client.py
+++ b/pytd/client.py
@@ -205,6 +205,12 @@ class Client(object):
               is set to ``"experimental"`` and ``engine`` denotes Hive.
               https://support.treasuredata.com/hc/en-us/articles/360027259074-How-to-use-Hive-2
 
+            Meanwhile, when a following argument is set to ``True``, query is
+            deterministically issued via ``tdclient``.
+
+            - ``force_tdclient`` (bool): force Presto engines to issue a query
+              via ``tdclient`` rather than its default ``prestodb`` interface.
+
         Returns
         -------
         dict : keys ('data', 'columns')

--- a/pytd/pandas_td/__init__.py
+++ b/pytd/pandas_td/__init__.py
@@ -178,6 +178,7 @@ def read_td_query(
     """
     if params is None:
         params = {}
+    params["force_tdclient"] = True
 
     if isinstance(engine, PrestoQueryEngine) and distributed_join is not None:
         header = engine.create_header(

--- a/pytd/pandas_td/__init__.py
+++ b/pytd/pandas_td/__init__.py
@@ -126,6 +126,11 @@ def read_td_query(
     Optionally provide an index_col parameter to use one of the columns as
     the index, otherwise default integer index will be used.
 
+    While Presto in pytd has two options to issue a query, by either
+    ``tdclient`` or ``prestodb``, pytd.pandas_td#read_td_query always uses the
+    former to be compatible with the original pandas-td. Use
+    :class:`pytd.Client` to take advantage of the latter option.
+
     Parameters
     ----------
     query : str

--- a/pytd/query_engine.py
+++ b/pytd/query_engine.py
@@ -306,7 +306,7 @@ class PrestoQueryEngine(QueryEngine):
 
         Returns
         -------
-        prestodb.dbapi.Cursor, or tdclient.cursor.Cursor
+        :class:`prestodb.dbapi.Cursor`, or :class:`tdclient.cursor.Cursor`
         """
         if not force_tdclient and len(kwargs) == 0:
             return self.prestodb_connection.cursor()

--- a/pytd/tests/test_query_engine.py
+++ b/pytd/tests/test_query_engine.py
@@ -85,6 +85,10 @@ class PrestoQueryEngineTestCase(unittest.TestCase):
         self.presto.cursor()
         self.assertTrue(self.presto.prestodb_connection.cursor.called)
 
+    def test_cursor_tdclient(self):
+        self.presto.cursor(force_tdclient=True)
+        self.assertTrue(self.presto.tdclient_connection.cursor.called)
+
     def test_cursor_with_params(self):
         self.presto.cursor(priority="LOW")
         self.assertTrue(self.presto.tdclient_connection.cursor.called)
@@ -133,6 +137,10 @@ class HiveQueryEngineTestCase(unittest.TestCase):
 
     def test_cursor(self):
         self.hive.cursor()
+        self.assertTrue(self.hive.engine.cursor.called)
+
+        # the `force_tdclient` flag has no effect for HiveQueryEngine
+        self.hive.cursor(force_tdclient=False)
         self.assertTrue(self.hive.engine.cursor.called)
 
     def test_close(self):


### PR DESCRIPTION
Resolve #84 by adding an option to manually choose which type of Cursor to be used by `PrestoQueryEngine`.

```py
>>> import pytd
>>> client = pytd.Client()
>>> client.query('select 1')
{'data': [[1]], 'columns': ['_col0']}
>>> client.query_executed
<prestodb.client.PrestoResult object at 0x116120e48>
>>> client.query('select 1', priority=0)
returning `tdclient.cursor.Cursor`. This cursor, `Cursor#fetchone` in particular, might behave different from your expectation, because it actually executes a job on Treasure Data and fetches all records at once from the job result.
{'data': [[1]], 'columns': ['_col0']}
>>> client.query_executed
'716477929'
>>> client.query('select 1', force_tdclient=True)
returning `tdclient.cursor.Cursor`. This cursor, `Cursor#fetchone` in particular, might behave different from your expectation, because it actually executes a job on Treasure Data and fetches all records at once from the job result.
{'data': [[1]], 'columns': ['_col0']}
>>> client.query_executed
'716478064'
```

```py
>>> import pytd.pandas_td as td
>>> engine = td.create_engine("presto:sample_datasets")
>>> td.read_td_query('select 1', engine)
returning `tdclient.cursor.Cursor`. This cursor, `Cursor#fetchone` in particular, might behave different from your expectation, because it actually executes a job on Treasure Data and fetches all records at once from the job result.
   _col0
0      1
```