### PR TITLE
Warn with invalid table argument for write_datafrme

### DIFF
--- a/pytd/tests/test_writer.py
+++ b/pytd/tests/test_writer.py
@@ -203,6 +203,10 @@ class InsertIntoWriterTestCase(unittest.TestCase):
                 pd.DataFrame([[1, 2], [3, 4]]), self.table, "error"
             )
 
+    def test_table(self):
+        with self.assertRaises(TypeError):
+            self.writer.write_dataframe(pd.DataFrame([[1, 2], [3, 4]]), "foo", "error")
+
 
 class BulkImportWriterTestCase(unittest.TestCase):
     def setUp(self):
@@ -361,6 +365,10 @@ class BulkImportWriterTestCase(unittest.TestCase):
                 pd.DataFrame([[1, 2], [3, 4]]), self.table, "error"
             )
 
+    def test_table(self):
+        with self.assertRaises(TypeError):
+            self.writer.write_dataframe(pd.DataFrame([[1, 2], [3, 4]]), "foo", "error")
+
 
 class SparkWriterTestCase(unittest.TestCase):
     def setUp(self):
@@ -442,3 +450,7 @@ class SparkWriterTestCase(unittest.TestCase):
             self.writer.write_dataframe(
                 pd.DataFrame([[1, 2], [3, 4]]), self.table, "error"
             )
+
+    def test_table(self):
+        with self.assertRaises(TypeError):
+            self.writer.write_dataframe(pd.DataFrame([[1, 2], [3, 4]]), "foo", "error")

--- a/pytd/writer.py
+++ b/pytd/writer.py
@@ -200,6 +200,11 @@ class InsertIntoWriter(Writer):
         if self.closed:
             raise RuntimeError("this writer is already closed and no longer available")
 
+        if isinstance(table, str):
+            raise TypeError(
+                "table '{}' should be pytd.table.Table, not str".format(table)
+            )
+
         _cast_dtypes(dataframe)
 
         column_names, column_types = _get_schema(dataframe)
@@ -404,6 +409,11 @@ class BulkImportWriter(Writer):
         """
         if self.closed:
             raise RuntimeError("this writer is already closed and no longer available")
+
+        if isinstance(table, str):
+            raise TypeError(
+                "table '{}' should be pytd.table.Table, not str".format(table)
+            )
 
         if "time" not in dataframe.columns:  # need time column for bulk import
             dataframe["time"] = int(time.time())
@@ -621,6 +631,11 @@ class SparkWriter(Writer):
 
         if if_exists not in ("error", "overwrite", "append", "ignore"):
             raise ValueError("invalid value for if_exists: {}".format(if_exists))
+
+        if isinstance(table, str):
+            raise TypeError(
+                "table '{}' should be pytd.table.Table, not str".format(table)
+            )
 
         if self.td_spark is None:
             self.td_spark = fetch_td_spark_context(


### PR DESCRIPTION
To avoid unexpected type for table argument in `writer.write_dataframe`, this PR adds type validation.