### PR TITLE
Use `join_distribution_type` for distributed join

### DIFF
--- a/pytd/pandas_td/__init__.py
+++ b/pytd/pandas_td/__init__.py
@@ -151,7 +151,7 @@ def read_td_query(
     distributed_join : bool, default: `False`
         (Presto only) If True, distributed join is enabled. If False, broadcast join is
         used.
-        See https://prestodb.io/docs/current/release/release-0.77.html
+        See https://trino.io/docs/current/admin/properties-general.html#join-distribution-type
 
     params : dict, optional
         Parameters to pass to execute method. pytd does not support parameter
@@ -189,8 +189,8 @@ def read_td_query(
         header = engine.create_header(
             [
                 "read_td_query",
-                "set session distributed_join = "
-                f"'{'true' if distributed_join else 'false'}'\n",
+                "set session join_distribution_type = "
+                f"'{'PARTITIONED' if distributed_join else 'BROADCAST'}'\n",
             ]
         )
     else:

--- a/pytd/pandas_td/__init__.py
+++ b/pytd/pandas_td/__init__.py
@@ -151,7 +151,7 @@ def read_td_query(
     distributed_join : bool, default: `False`
         (Presto only) If True, distributed join is enabled. If False, broadcast join is
         used.
-        See https://trino.io/docs/current/admin/properties-general.html#join-distribution-type
+        See https://trino.io/docs/current/admin/properties-general.html
 
     params : dict, optional
         Parameters to pass to execute method. pytd does not support parameter


### PR DESCRIPTION
Close #99

Presto (Trino) no longer supports `distributed_join` option.
The option doesn't work on Treasure Data too. So I replaced the new
option.
See: https://tddocs.atlassian.net/wiki/spaces/PD/pages/6258808/Presto+0.205+to+317+Migration+2020#Migrate-Your-Distributed-Joins

Job (934924350) returned:

```
-- client: pytd/1.4.0 (prestodb/0.7.0; tdclient/1.1.0)
-- read_td_query
-- set session join_distribution_type = 'BROADCAST'
SELECT 
   *
FROM
  pytd LIMIT 1
```