### PR TITLE
Revert "Bump to v1.4.1"

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,11 +1,6 @@
 Changelog
 =========
 
-v1.4.1 (2021-02-10)
--------------------
-
-- Presto queries issued by ``pandas_td.read_td_query`` use ``join_distribution_type`` session property instead of the deprecated ``distributed_join`` property. See our `documentation <https://docs.treasuredata.com/display/public/PD/Presto+0.205+to+317+Migration+2020#Presto0.205to317Migration2020-DeprecatedFeatures>`__ for more information about the change. (`#100 <https://github.com/treasure-data/pytd/pull/100>`__)
-
 v1.4.0 (2021-01-11)
 -------------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pytd
-version = 1.4.1
+version = 1.4.0
 summary = Treasure Data Driver for Python
 author = Treasure Data
 author_email = support@treasure-data.com


### PR DESCRIPTION
Reverts treasure-data/pytd#103

A broken package has mistakenly been uploaded to PyPI, and we deleted the version immediately. Since we cannot re-upload the same version number again, pytd must skip this version number.