### PR TITLE
[hot fix] Set upper version for pandas

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ python_requires = >=3.6,<3.9
 install_requires =
     urllib3<1.25,>=1.21.1
     presto-python-client>=0.6.0
-    pandas>=0.25.0
+    pandas>=0.25.0,<1.2
     td-client>=1.1.0
     pytz>=2018.5
     numpy<1.20


### PR DESCRIPTION
While digdag-python:3.7 uses numpy 1.16.14, pandas 1.2 drops it. For
stability, will set upper version of pandas for while.