### PR TITLE
Add newer Python support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       max-parallel: 2
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9, 3.10]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,12 +14,12 @@ jobs:
       max-parallel: 2
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9, 3.10]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,10 +21,12 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
 
 [options]
 packages = find:
-python_requires = >=3.6,<3.9
+python_requires = >=3.6,<3.11
 install_requires =
     urllib3~=1.26,>=1.21.1
     presto-python-client>=0.6.0


### PR DESCRIPTION
pytd requires < Python 3.9 now. Although the latest stable version is 3.10, we still support only between 3.6 and 3.8.
Because Treasure Data custom script uses Python 3.9 to default, we need to support 3.9 at least.

So, we have to consider dropping older and adding newer versions of Python.

What do you think about it?