### PR TITLE
Release 1.5.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-v1.5.0 (2022-12-06)
+v1.5.1 (2022-12-08)
 -------------------
 
 - Updated dependencies and pytd now supports python 3.9 and 3.10

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pytd
-version = 1.5.0
+version = 1.5.1
 summary = Treasure Data Driver for Python
 author = Treasure Data
 author_email = support@treasure-data.com


### PR DESCRIPTION
* this is almost identical PR to PR release 1.5.0 to fix "This filename has already been used, use a different version" issue.

Changelog:
- Updated dependencies and pytd now supports python 3.9 and 3.10