### PR TITLE
Use `obj.items` instead of `iteritems()`

### DIFF
--- a/pytd/writer.py
+++ b/pytd/writer.py
@@ -94,7 +94,7 @@ def _cast_dtypes(dataframe, inplace=True, keep_list=False):
     """
     df = dataframe if inplace else dataframe.copy()
 
-    for column, kind in dataframe.dtypes.apply(lambda dtype: dtype.kind).iteritems():
+    for column, kind in dataframe.dtypes.apply(lambda dtype: dtype.kind).items():
         t = str
         if kind in ("i", "u"):
             t = "Int64" if df[column].isnull().any() else "int64"


### PR DESCRIPTION
`iteritems()` has dropped since pandas v2.0.0.
https://pandas.pydata.org/docs/whatsnew/v2.0.0.html#deprecations

It's true that pytd depends on pandas <1.6, but users will get failures if a user script including Treasure Data Custom Script imports the latest pandas. Actually, some issues were raised by plural customers as to this deprecation.

Therefore, I revised a function to use `obj.items` instead of `iteritems()`. This change will calm down the warning messages and can avoid errors that the runtime can't find the deprecated function.

**Before**

```
>>> import sys
>>> sys.path.append('/pytd')
>>> import pytd
>>> import numpy as np
>>> import pandas as pd
>>>
>>> client = pytd.Client()
>>> df = pd.DataFrame({"a": [[1,2,3], [2,3,4]], "b": [[0, None, 2], [2,3,4]]})
>>> table = pytd.table.Table(client, "akito_test", "test")
>>>
>>> writer = pytd.writer.BulkImportWriter()
>>> writer.write_dataframe(df, table, if_exists="overwrite", keep_list=True)
/Users/akito.kasai/src/github.com/treasure-data/pytd/pytd/writer.py:97: FutureWarning: iteritems is deprecated and will be removed in a future version. Use   .items instead.
  for column, kind in dataframe.dtypes.apply(lambda dtype: dtype.kind).iteritems():
uploading data converted into a msgpack file
performing a bulk import job
[job id 1770908810] imported 2 records.
```

**After**

```
>>> import sys
>>> sys.path.append('/pytd')
>>> sys.path
['', '/opt/homebrew/Cellar/python@3.11/3.11.2_1/Frameworks/Python.framework/Versions/3.11/lib/python311.zip', '/opt/homebrew/Cellar/python@3.11/3.11.2_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11', '/opt/homebrew/Cellar/python@3.11/3.11.2_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload', '/opt/homebrew/lib/python3.11/site-packages', '/opt/homebrew/Cellar/pygments/2.14.0/libexec/lib/python3.11/site-packages', '/pytd']
>>> import pytd
>>> import numpy as np
>>> import pandas as pd
>>>
>>> client = pytd.Client()
>>> df = pd.DataFrame({"a": [[1,2,3], [2,3,4]], "b": [[0, None, 2], [2,3,4]]})
>>> table = pytd.table.Table(client, "akito_test", "test")
>>> writer = pytd.writer.BulkImportWriter()
>>>
>>> writer.write_dataframe(df, table, if_exists='overwrite', keep_list=True)
uploading data converted into a msgpack file
performing a bulk import job
[job id 1770913878] imported 2 records.
```

**Environment**

```
% python3 --version
Python 3.11.2
```

And, using the edge of pytd master branch.