### PR TITLE
Keep single quotes in InsertIntoWriter

### DIFF
--- a/pytd/writer.py
+++ b/pytd/writer.py
@@ -286,9 +286,13 @@ class InsertIntoWriter(Writer):
         """
         rows = []
         for tpl in list_of_tuple:
+            # InsertIntoWriter kicks Presto (Trino).
+            # Following the list comprehension makes a single quote duplicated because
+            # Presto allows users to escape a single quote with another single quote.
+            # e.g. 'John Doe''s name' is converted to "John Doe's name" on Presto.
             list_of_value_strings = [
                 (
-                    f"""'{e.replace("'", '"')}'"""
+                    f"""'{e.replace("'", "''")}'"""
                     if isinstance(e, str)
                     else ("null" if pd.isnull(e) else str(e))
                 )


### PR DESCRIPTION
### What's changed

InsertIntoWriter converts a single quote to a double quote because single quotes are reserved for string literals and double quotes are column names.

However, this conversion will break users' characters when their data have a single quote.
For example, current behavior changes `St. Patrick's day` to `St. Patrick"s day` implicitly.

To eliminate this issue, this pull request aims to keep single quotes.

### Example

Prepare the following code and run:

```
>>> import pytd
>>> import pandas as pd
>>> client = pytd.Client()
>>> df = pd.DataFrame(data={'name': ["John' Doe"], 'email': ['john.doe@example.com'], 'description': ["Add two single quotes '', then insert new line \nfor a test."]})
>>> client.load_table_from_dataframe(df, 'akito_test.mytest', writer='insert_into', if_exists='append')
```

Then, pytd kicks the following queries and results:

**(1) Current behavior (converted single quote to double quote)**
Job Info

```
% td job:show 1815467019
JobID       : 1815467019
...
Start At    : 2023-05-18 08:29:41 UTC
End At      : 2023-05-18 08:29:42 UTC
...
Query       : -- client: pytd/1.4.0 (prestodb/0.8.3; tdclient/1.2.1)
-- Client#query
INSERT INTO akito_test.mytest (name, email, description) VALUES ('John" Doe', 'john.doe@example.com', 'Add two single quotes "", then insert new line
for a test.')
```

![Screenshot 2023-05-18 at 22 10 58](https://github.com/treasure-data/pytd/assets/8242734/b6253b84-8ade-4661-a2b3-ec28c3ae31f6)


**(2) New behavior (keep single quote)**

Job Info:

```
 % td job:show 1815470950
JobID       : 1815470950
...
Start At    : 2023-05-18 08:33:05 UTC
End At      : 2023-05-18 08:33:07 UTC
...
Query       : -- client: pytd/1.4.0 (prestodb/0.8.3; tdclient/1.2.1)
-- Client#query
INSERT INTO akito_test.mytest (name, email, description) VALUES ('John'' Doe', 'john.doe@example.com', 'Add two single quotes '''', then insert new line
for a test.')
```

![Screenshot 2023-05-18 at 22 13 18](https://github.com/treasure-data/pytd/assets/8242734/49a33c26-a275-442f-8421-1a10bd4ccdf3)

`InsertIntoWriter` could send single quotes without modification.
