### PR TITLE
Handle cases with cur.description is None

### DIFF
--- a/pytd/query_engine.py
+++ b/pytd/query_engine.py
@@ -96,7 +96,7 @@ class QueryEngine(metaclass=abc.ABCMeta):
         self.executed = cur.execute(query)
         rows = cur.fetchall()
         # cur.description is None for CREATE and DROP statements in recent version of Trino
-        columns = [desc[0] for desc in cur.description] if cur.description else []
+        columns = [desc[0] for desc in cur.description] if cur.description else None
         return {"data": rows, "columns": columns}
 
     def create_header(self, extra_lines=[]):

--- a/pytd/query_engine.py
+++ b/pytd/query_engine.py
@@ -95,7 +95,8 @@ class QueryEngine(metaclass=abc.ABCMeta):
         cur = self.cursor(**kwargs)
         self.executed = cur.execute(query)
         rows = cur.fetchall()
-        columns = [desc[0] for desc in cur.description]
+        # cur.description is None for CREATE and DROP statements in recent version of Trino
+        columns = [desc[0] for desc in cur.description] if cur.description else []
         return {"data": rows, "columns": columns}
 
     def create_header(self, extra_lines=[]):


### PR DESCRIPTION
## Problem

Since [this change of Trino](https://github.com/trinodb/trino/pull/13907), `cur.description` is None for `DROP` and `CREATE` statements.
This causes `'NoneType' object is not iterable` in the pytd side.

This PR adds handling of cases with `cur.description is None`.

## Alternatives and Why Not?

We can return `None` instead of an empty list but an empty list keeps the same typing