### PR TITLE
Release 1.5.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,11 +1,17 @@
 Changelog
 =========
 
+v1.5.2 (2024-06-03)
+-------------------
+
+- Handle cases with cur.description is None 
+- Keep single quotes in InsertIntoWriter
+- Use obj.items instead of iteritems() 
+
 v1.5.1 (2022-12-08)
 -------------------
 
 - Updated dependencies and pytd now supports python 3.9 and 3.10
-
 
 v1.4.4 (2022-09-06)
 -------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pytd
-version = 1.5.1
+version = 1.5.2
 summary = Treasure Data Driver for Python
 author = Treasure Data
 author_email = support@treasure-data.com


### PR DESCRIPTION
- Handle cases with cur.description is None 
- Keep single quotes in InsertIntoWriter
- Use obj.items instead of iteritems() 
