### PR TITLE
Add support for Python 3.11. Remove support for Python 3.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,15 +14,9 @@ jobs:
       max-parallel: 2
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
-        pandas-version: ["1.2.5", "1.3.5", "1.4.4", "1.5.2"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        pandas-version: ["1.3.5", "1.4.4", "1.5.3"]
         exclude:
-          - python-version: "3.7"
-            pandas-version: "1.4.4"
-          - python-version: "3.7"
-            pandas-version: "1.5.2"
-          - python-version: "3.10"
-            pandas-version: "1.2.5"
           - python-version: "3.10"
             pandas-version: "1.3.5"
           - python-version: "3.10"

--- a/noxfile.py
+++ b/noxfile.py
@@ -16,11 +16,8 @@ def lint(session):
     "python,pandas",
     [
         (python, pandas)
-        for python in ("3.7", "3.8", "3.9", "3.10")
-        for pandas in ("1.2.5", "1.3.5", "1.4.4", "1.5.2")
-        if (python, pandas) != ("3.7", "1.4.4")
-        if (python, pandas) != ("3.7", "1.5.2")
-        if (python, pandas) != ("3.10", "1.2.5")
+        for python in ("3.8", "3.9", "3.10", "3.11")
+        for pandas in ("1.3.5", "1.4.4", "1.5.3")
         if (python, pandas) != ("3.10", "1.3.5")
         if (python, pandas) != ("3.10", "1.4.4")
     ],

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,15 +19,14 @@ classifiers =
     Topic :: Database
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
 
 [options]
 packages = find:
-python_requires = >=3.7,<3.11
+python_requires = >=3.7,<3.12
 install_requires =
     urllib3~=1.26,>=1.21.1
     presto-python-client>=0.6.0


### PR DESCRIPTION
### Purpose

We want to add support for python 3.11, while remove support for python 3.7 due to end-of-life status

### Overview

- Run CI test for python 3.11
- Drop CI test for 3.7
- Update setup.cfg to reflect added support for 3.11 and remove support for 3.7