### PR TITLE
Add parallel upload for BulkImportWriter

### DIFF
--- a/pytd/tests/test_writer.py
+++ b/pytd/tests/test_writer.py
@@ -279,7 +279,9 @@ class BulkImportWriterTestCase(unittest.TestCase):
         self.assertTrue(api_client.create_bulk_import.called)
         self.assertTrue(api_client.create_bulk_import().upload_part.called)
         with tempfile.NamedTemporaryFile(delete=False) as fp:
-            fp = BulkImportWriter()._write_msgpack_stream(df.to_dict(orient="records"), fp)
+            fp = BulkImportWriter()._write_msgpack_stream(
+                df.to_dict(orient="records"), fp
+            )
             api_client.create_bulk_import().upload_part.assert_called_with(
                 "part-0", ANY, 62
             )
@@ -295,10 +297,10 @@ class BulkImportWriterTestCase(unittest.TestCase):
             ],
             dtype="Int64",
         )
-        expected_list = (
+        expected_list = [
             {"a": 1, "b": 2, "c": None, "time": 1234},
             {"a": 3, "b": 4, "c": 5, "time": 1234},
-        )
+        ]
         self.writer._write_msgpack_stream = MagicMock()
         with patch("pytd.writer.os.unlink"):
             self.writer.write_dataframe(df, self.table, "overwrite", fmt="msgpack")
@@ -315,10 +317,10 @@ class BulkImportWriterTestCase(unittest.TestCase):
             dtype="string",
         )
         df["time"] = 1234
-        expected_list = (
+        expected_list = [
             {"a": "foo", "b": "bar", "c": None, "time": 1234},
             {"a": "buzz", "b": "buzz", "c": "alice", "time": 1234},
-        )
+        ]
         self.writer._write_msgpack_stream = MagicMock()
         with patch("pytd.writer.os.unlink"):
             self.writer.write_dataframe(df, self.table, "overwrite", fmt="msgpack")
@@ -334,10 +336,10 @@ class BulkImportWriterTestCase(unittest.TestCase):
             dtype="boolean",
         )
         df["time"] = 1234
-        expected_list = (
+        expected_list = [
             {"a": "true", "b": "false", "c": None, "time": 1234},
             {"a": "false", "b": "true", "c": "true", "time": 1234},
-        )
+        ]
         self.writer._write_msgpack_stream = MagicMock()
         with patch("pytd.writer.os.unlink"):
             self.writer.write_dataframe(df, self.table, "overwrite", fmt="msgpack")

--- a/pytd/tests/test_writer.py
+++ b/pytd/tests/test_writer.py
@@ -1,7 +1,7 @@
-import io
 import os
+import tempfile
 import unittest
-from unittest.mock import ANY, MagicMock
+from unittest.mock import ANY, MagicMock, patch
 
 import numpy as np
 import pandas as pd
@@ -89,9 +89,6 @@ class WriterTestCase(unittest.TestCase):
         # This is for consistency of _get_schema
         self.assertTrue(pd.isna(dft["O"][2]))
 
-    @unittest.skipIf(
-        pd.__version__ < "1.0.0", "pd.NA is not supported in this pandas version"
-    )
     def test_cast_dtypes_nullable(self):
         dft = pd.DataFrame(
             {
@@ -281,14 +278,12 @@ class BulkImportWriterTestCase(unittest.TestCase):
         api_client = self.table.client.api_client
         self.assertTrue(api_client.create_bulk_import.called)
         self.assertTrue(api_client.create_bulk_import().upload_part.called)
-        _bytes = BulkImportWriter()._write_msgpack_stream(
-            df.to_dict(orient="records"), io.BytesIO()
-        )
-        size = _bytes.getbuffer().nbytes
-        api_client.create_bulk_import().upload_part.assert_called_with(
-            "part-0", ANY, size
-        )
-        self.assertFalse(api_client.create_bulk_import().upload_file.called)
+        with tempfile.NamedTemporaryFile(delete=False) as fp:
+            fp = BulkImportWriter()._write_msgpack_stream(df.to_dict(orient="records"), fp)
+            api_client.create_bulk_import().upload_part.assert_called_with(
+                "part-0", ANY, 62
+            )
+            self.assertFalse(api_client.create_bulk_import().upload_file.called)
 
     def test_write_dataframe_msgpack_with_int_na(self):
         # Although this conversion ensures pd.NA Int64 dtype to None,
@@ -305,17 +300,15 @@ class BulkImportWriterTestCase(unittest.TestCase):
             {"a": 3, "b": 4, "c": 5, "time": 1234},
         )
         self.writer._write_msgpack_stream = MagicMock()
-        self.writer.write_dataframe(df, self.table, "overwrite", fmt="msgpack")
-        self.assertTrue(self.writer._write_msgpack_stream.called)
-        print(self.writer._write_msgpack_stream.call_args[0][0][0:2])
-        self.assertEqual(
-            self.writer._write_msgpack_stream.call_args[0][0][0:2],
-            expected_list,
-        )
+        with patch("pytd.writer.os.unlink"):
+            self.writer.write_dataframe(df, self.table, "overwrite", fmt="msgpack")
+            self.assertTrue(self.writer._write_msgpack_stream.called)
+            print(self.writer._write_msgpack_stream.call_args[0][0][0:2])
+            self.assertEqual(
+                self.writer._write_msgpack_stream.call_args[0][0][0:2],
+                expected_list,
+            )
 
-    @unittest.skipIf(
-        pd.__version__ < "1.0.0", "pd.NA not supported in this pandas version"
-    )
     def test_write_dataframe_msgpack_with_string_na(self):
         df = pd.DataFrame(
             data=[{"a": "foo", "b": "bar"}, {"a": "buzz", "b": "buzz", "c": "alice"}],
@@ -327,16 +320,14 @@ class BulkImportWriterTestCase(unittest.TestCase):
             {"a": "buzz", "b": "buzz", "c": "alice", "time": 1234},
         )
         self.writer._write_msgpack_stream = MagicMock()
-        self.writer.write_dataframe(df, self.table, "overwrite", fmt="msgpack")
-        self.assertTrue(self.writer._write_msgpack_stream.called)
-        self.assertEqual(
-            self.writer._write_msgpack_stream.call_args[0][0][0:2],
-            expected_list,
-        )
+        with patch("pytd.writer.os.unlink"):
+            self.writer.write_dataframe(df, self.table, "overwrite", fmt="msgpack")
+            self.assertTrue(self.writer._write_msgpack_stream.called)
+            self.assertEqual(
+                self.writer._write_msgpack_stream.call_args[0][0][0:2],
+                expected_list,
+            )
 
-    @unittest.skipIf(
-        pd.__version__ < "1.0.0", "pd.NA not supported in this pandas version"
-    )
     def test_write_dataframe_msgpack_with_boolean_na(self):
         df = pd.DataFrame(
             data=[{"a": True, "b": False}, {"a": False, "b": True, "c": True}],
@@ -348,12 +339,13 @@ class BulkImportWriterTestCase(unittest.TestCase):
             {"a": "false", "b": "true", "c": "true", "time": 1234},
         )
         self.writer._write_msgpack_stream = MagicMock()
-        self.writer.write_dataframe(df, self.table, "overwrite", fmt="msgpack")
-        self.assertTrue(self.writer._write_msgpack_stream.called)
-        self.assertEqual(
-            self.writer._write_msgpack_stream.call_args[0][0][0:2],
-            expected_list,
-        )
+        with patch("pytd.writer.os.unlink"):
+            self.writer.write_dataframe(df, self.table, "overwrite", fmt="msgpack")
+            self.assertTrue(self.writer._write_msgpack_stream.called)
+            self.assertEqual(
+                self.writer._write_msgpack_stream.call_args[0][0][0:2],
+                expected_list,
+            )
 
     def test_write_dataframe_invalid_if_exists(self):
         with self.assertRaises(ValueError):
@@ -412,9 +404,6 @@ class SparkWriterTestCase(unittest.TestCase):
             self.writer.td_spark.spark.createDataFrame.call_args[0][0], expected_df
         )
 
-    @unittest.skipIf(
-        pd.__version__ < "1.0.0", "pd.NA is not supported in this pandas version"
-    )
     def test_write_dataframe_with_string_na(self):
         df = pd.DataFrame(
             data=[{"a": "foo", "b": "bar"}, {"a": "buzz", "b": "buzz", "c": "alice"}],
@@ -427,9 +416,6 @@ class SparkWriterTestCase(unittest.TestCase):
             self.writer.td_spark.spark.createDataFrame.call_args[0][0], expected_df
         )
 
-    @unittest.skipIf(
-        pd.__version__ < "1.0.0", "pd.NA is not supported in this pandas version"
-    )
     def test_write_dataframe_with_boolean_na(self):
         df = pd.DataFrame(
             data=[{"a": True, "b": False}, {"a": False, "b": True, "c": True}],

--- a/pytd/writer.py
+++ b/pytd/writer.py
@@ -472,7 +472,7 @@ class BulkImportWriter(Writer):
             self._bulk_import(table, fps, if_exists, fmt, max_workers=max_workers)
             stack.close()
 
-    def _bulk_import(self, table, file_like, if_exists, fmt="csv", max_workers=5):
+    def _bulk_import(self, table, file_likes, if_exists, fmt="csv", max_workers=5):
         """Write a specified CSV file to a Treasure Data table.
 
         This method uploads the file to Treasure Data via bulk import API.
@@ -482,7 +482,7 @@ class BulkImportWriter(Writer):
         table : :class:`pytd.table.Table`
             Target table.
 
-        file_like : List of file like objects
+        file_likes : List of file like objects
             Data in this file will be loaded to a target table.
 
         if_exists : str, {'error', 'overwrite', 'append', 'ignore'}
@@ -528,7 +528,7 @@ class BulkImportWriter(Writer):
             logger.info(f"uploading data converted into a {fmt} file")
             if fmt == "msgpack":
                 with ThreadPoolExecutor(max_workers=max_workers) as executor:
-                    for i, fp in enumerate(file_like):
+                    for i, fp in enumerate(file_likes):
                         fsize = fp.tell()
                         fp.seek(0)
                         executor.submit(
@@ -539,7 +539,7 @@ class BulkImportWriter(Writer):
                         )
                         logger.debug(f"to upload {fp.name} to TD. File size: {fsize}B")
             else:
-                fp = file_like[0]
+                fp = file_likes[0]
                 bulk_import.upload_file("part", fmt, fp)
             bulk_import.freeze()
         except Exception as e:

--- a/pytd/writer.py
+++ b/pytd/writer.py
@@ -6,7 +6,9 @@ import os
 import tempfile
 import time
 import uuid
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import ExitStack
+from itertools import zip_longest
 
 import msgpack
 import numpy as np
@@ -308,7 +310,9 @@ class BulkImportWriter(Writer):
     td-client-python's bulk importer.
     """
 
-    def write_dataframe(self, dataframe, table, if_exists, fmt="csv", keep_list=False):
+    def write_dataframe(
+        self, dataframe, table, if_exists, fmt="csv", keep_list=False, max_workers=5
+    ):
         """Write a given DataFrame to a Treasure Data table.
 
         This method internally converts a given :class:`pandas.DataFrame` into a
@@ -403,6 +407,10 @@ class BulkImportWriter(Writer):
             Or, you can use :func:`Client.load_table_from_dataframe` function as well.
 
             >>> client.load_table_from_dataframe(df, "bulk_import", keep_list=True)
+        
+        max_workers : int, optional, default: 5
+            The maximum number of threads that can be used to execute the given calls.
+            This is used only when ``fmt`` is ``msgpack``.
         """
         if self.closed:
             raise RuntimeError("this writer is already closed and no longer available")
@@ -420,26 +428,31 @@ class BulkImportWriter(Writer):
         _cast_dtypes(dataframe, keep_list=keep_list)
 
         with ExitStack() as stack:
+            fps = []
             if fmt == "csv":
                 fp = tempfile.NamedTemporaryFile(suffix=".csv", delete=False)
                 stack.callback(os.unlink, fp.name)
                 stack.callback(fp.close)
                 dataframe.to_csv(fp.name)
+                fps.append(fp)
             elif fmt == "msgpack":
                 _replace_pd_na(dataframe)
 
-                fp = io.BytesIO()
-                fp = self._write_msgpack_stream(dataframe.to_dict(orient="records"), fp)
-                stack.callback(fp.close)
+                records = dataframe.to_dict(orient="records")
+                for group in zip_longest(*(iter(records),) * 10000):
+                    fp = io.BytesIO()
+                    fp = self._write_msgpack_stream(group, fp)
+                    fps.append(fp)
+                    stack.callback(fp.close)
             else:
                 raise ValueError(
                     f"unsupported format '{fmt}' for bulk import. "
                     "should be 'csv' or 'msgpack'"
                 )
-            self._bulk_import(table, fp, if_exists, fmt)
+            self._bulk_import(table, fps, if_exists, fmt, max_workers=max_workers)
             stack.close()
 
-    def _bulk_import(self, table, file_like, if_exists, fmt="csv"):
+    def _bulk_import(self, table, file_like, if_exists, fmt="csv", max_workers=5):
         """Write a specified CSV file to a Treasure Data table.
 
         This method uploads the file to Treasure Data via bulk import API.
@@ -449,7 +462,7 @@ class BulkImportWriter(Writer):
         table : :class:`pytd.table.Table`
             Target table.
 
-        file_like : File like object
+        file_like : List of file like objects
             Data in this file will be loaded to a target table.
 
         if_exists : str, {'error', 'overwrite', 'append', 'ignore'}
@@ -462,6 +475,10 @@ class BulkImportWriter(Writer):
 
         fmt : str, optional, {'csv', 'msgpack'}, default: 'csv'
             File format for bulk import. See also :func:`write_dataframe`
+
+        max_workers : int, optional, default: 5
+            The maximum number of threads that can be used to execute the given calls.
+            This is used only when ``fmt`` is ``msgpack``.
         """
         params = None
         if table.exists:
@@ -489,11 +506,19 @@ class BulkImportWriter(Writer):
         try:
             logger.info(f"uploading data converted into a {fmt} file")
             if fmt == "msgpack":
-                size = file_like.getbuffer().nbytes
-                # To skip API._prepare_file(), which recreate msgpack again.
-                bulk_import.upload_part("part", file_like, size)
+                with ThreadPoolExecutor(max_workers=max_workers) as executor:
+                    _ = [
+                        executor.submit(
+                            bulk_import.upload_part,
+                            f"part-{i}",
+                            fp,
+                            fp.getbuffer().nbytes,
+                        )
+                        for i, fp in enumerate(file_like)
+                    ]
             else:
-                bulk_import.upload_file("part", fmt, file_like)
+                fp = file_like[0]
+                bulk_import.upload_file("part", fmt, fp)
             bulk_import.freeze()
         except Exception as e:
             bulk_import.delete()
@@ -535,6 +560,9 @@ class BulkImportWriter(Writer):
         with gzip.GzipFile(mode="wb", fileobj=stream) as gz:
             packer = msgpack.Packer()
             for item in items:
+                # Ignore None created by zip_longest
+                if not item:
+                    break
                 try:
                     mp = packer.pack(item)
                 except (OverflowError, ValueError):

--- a/pytd/writer.py
+++ b/pytd/writer.py
@@ -462,7 +462,7 @@ class BulkImportWriter(Writer):
                 except OSError as e:
                     raise RuntimeError(
                         "failed to create a temporary file. "
-                        "Increase chunk_record_size may mitigate the issue."
+                        "Larger chunk_record_size may mitigate the issue."
                     ) from e
             else:
                 raise ValueError(


### PR DESCRIPTION
This patch introduces parallel upload capability to BulkImportWriter.

It makes a chunk of 10,000 records and uploads in parallel. Also, it reduces memory consumption for msgpack format uploading.

Upload speed becomes x4.4 faster, and memory consumption can be controlled by using Temporary file and `chunk_record_size` number.

## Dummy data creation for benchmark

```py
>>> import numpy as np; import pandas as pd
>>> def fake_data(n):
...    users = np.random.choice([0., 1., 2.], (n, 1))
...    items = np.random.choice([0., 1., 2.], (n, 1))
...    weight = np.random.rand(n,1)
...    return np.concatenate((users, items, weight), axis=1)
...
>>> d1 = fake_data(10_000_000)
>>> df = pd.DataFrame(d1, columns=["users", "items", "scores"])
>>> import pytd; import os
>>> client=pytd.Client(database="aki", apikey=os.environ["TD_API_KEY"])
```


## Upload with a single thread


```py
>>> import time
>>> s=time.time()
>>> client.load_table_from_dataframe(df, "aki.pytd_bi_test", writer="bulk_import", if_exists="overwrite", fmt="msgpack", max_workers=1, chunk_record_size=10_000_000)
>>> print(f"elapsed time:{time.time() - s} sec")
uploading data converted into a msgpack file
uploaded data in 64.06 sec
performing a bulk import job
[job id 2172780406] imported 10000000 records.
elapsed time:281.57144117355347 sec
```

## Upload with 6 threads

```py
>>> import pytd; import os
>>> import time
>>> s=time.time()
>>> client.load_table_from_dataframe(df, "aki.pytd_bi_test", writer="bulk_import", if_exists="overwrite", fmt="msgpack", max_workers=6, chunk_record_size=1_000_000)
>>> print(f"elapsed time:{time.time() - s} sec")
uploading data converted into a msgpack file
uploaded data in 14.56 sec
performing a bulk import job
[job id 2172780795] imported 10000000 records.
elapsed time:209.5141899585724 sec
```