### PR TITLE
Use importlib.metadata instead of pkg_resources since deprecated

### DIFF
--- a/pytd/__init__.py
+++ b/pytd/__init__.py
@@ -1,10 +1,9 @@
+import importlib.metadata
 import logging
-
-import pkg_resources
 
 from .client import Client
 
-__version__ = pkg_resources.get_distribution("pytd").version
+__version__ = importlib.metadata.version("pytd")
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.StreamHandler())
 logger.setLevel(logging.INFO)

--- a/pytd/query_engine.py
+++ b/pytd/query_engine.py
@@ -1,13 +1,13 @@
 import abc
+import importlib.metadata
 import logging
 import os
 from urllib.parse import urlparse
 
-import pkg_resources
 import prestodb
 import tdclient
 
-__version__ = pkg_resources.get_distribution("pytd").version
+__version__ = importlib.metadata.version("pytd")
 
 logger = logging.getLogger(__name__)
 
@@ -95,7 +95,8 @@ class QueryEngine(metaclass=abc.ABCMeta):
         cur = self.cursor(**kwargs)
         self.executed = cur.execute(query)
         rows = cur.fetchall()
-        # cur.description is None for CREATE and DROP statements in recent version of Trino
+        # cur.description is None for CREATE and DROP statements in recent version of
+        # Trino
         columns = [desc[0] for desc in cur.description] if cur.description else None
         return {"data": rows, "columns": columns}
 


### PR DESCRIPTION

See: https://setuptools.pypa.io/en/latest/pkg_resources.html


Suppress the following warning

```py
============================================================================ warnings summary =============================================================================
pytd/query_engine.py:6
  /Users/ariga/src/pytd/pytd/query_engine.py:6: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
    import pkg_resources

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```