### PR TITLE
Require numpy minimum version of 1.17.3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
     urllib3>=1.21.1
     presto-python-client>=0.6.0
     pandas>=1.3
-    numpy>1.17.3
+    numpy>1.17.3, <2.0.0
     td-client>=1.1.0
     pytz>=2018.5
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,9 +31,9 @@ install_requires =
     urllib3>=1.21.1
     presto-python-client>=0.6.0
     pandas>=1.3
+    numpy>1.17.3
     td-client>=1.1.0
     pytz>=2018.5
-    numpy<1.24
 
 [options.extras_require]
 spark =


### PR DESCRIPTION
Support numpy version from 1.17.3 (for pandas 1.3), and cap below 2.0.0 (pandas supports numpy 2.0 after 2.2.2)