### PR TITLE
Release 1.7.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+v1.7.0 (2024-09-20)
+-------------------
+
+- New parallel upload feature. Use two new parameters max_workers and chunk_record_size in Client’s load_table_from_dataframe api to configure parallelization of uploading data to Treasure Data, saving time
+- Support for pandas 2
+- Increase supported numpy versions to between 1.17.3 and less than 2.0.0
+
 v1.6.0 (2024-08-26)
 -------------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pytd
-version = 1.6.0
+version = 1.7.0
 summary = Treasure Data Driver for Python
 author = Treasure Data
 author_email = support@treasure-data.com


### PR DESCRIPTION
Changelog:

- New parallel upload feature. Use two new parameters max_workers and chunk_record_size in Client’s load_table_from_dataframe api to configure parallelization of uploading data to Treasure Data, saving time.
- Support for pandas 2
- Increase supported numpy versions to between 1.17.3 and less than 2.0.0

