### PR TITLE
[Bugfix] Presto API URL Inferrence

### DIFF
--- a/pytd/query_engine.py
+++ b/pytd/query_engine.py
@@ -275,11 +275,15 @@ class PrestoQueryEngine(QueryEngine):
         inferred from Treasure Data REST API endpoint.
         """
         url = urlparse(self.endpoint).netloc
-        stage = url.split("-")[1]
-        return os.getenv(
-            "TD_PRESTO_API",
-            url.replace(stage, f"{stage}-presto"),
-        )
+        url_components = url.split("-")
+        if len(url_components) > 1:
+            stage = url_components[1]
+            return os.getenv(
+                "TD_PRESTO_API",
+                url.replace(stage, f"{stage}-presto"),
+            )
+        else:
+            return os.getenv("TD_PRESTO_API", url.replace("api", "api-presto"))
 
     def cursor(self, force_tdclient=False, **kwargs):
         """Get cursor defined by DB-API.

--- a/pytd/query_engine.py
+++ b/pytd/query_engine.py
@@ -274,8 +274,11 @@ class PrestoQueryEngine(QueryEngine):
         """Presto API host obtained from ``TD_PRESTO_API`` env variable or
         inferred from Treasure Data REST API endpoint.
         """
+        url = urlparse(self.endpoint).netloc
+        stage = url.split("-")[1]
         return os.getenv(
-            "TD_PRESTO_API", urlparse(self.endpoint).netloc.replace("api", "api-presto")
+            "TD_PRESTO_API",
+            url.replace(stage, f"{stage}-presto"),
         )
 
     def cursor(self, force_tdclient=False, **kwargs):

--- a/pytd/query_engine.py
+++ b/pytd/query_engine.py
@@ -275,15 +275,13 @@ class PrestoQueryEngine(QueryEngine):
         inferred from Treasure Data REST API endpoint.
         """
         url = urlparse(self.endpoint).netloc
-        url_components = url.split("-")
-        if len(url_components) > 1:
-            stage = url_components[1]
-            return os.getenv(
-                "TD_PRESTO_API",
-                url.replace(stage, f"{stage}-presto"),
-            )
-        else:
-            return os.getenv("TD_PRESTO_API", url.replace("api", "api-presto"))
+        stage = url.split("-")[1] if len(url.split("-")) > 1 else None
+        return os.getenv(
+            "TD_PRESTO_API",
+            url.replace(stage, f"{stage}-presto")
+            if stage
+            else url.replace("api", "api-presto"),
+        )
 
     def cursor(self, force_tdclient=False, **kwargs):
         """Get cursor defined by DB-API.


### PR DESCRIPTION
### Introduction

Currently, if the `TD_PRESTO_API` env variable is not set - it's attempted to be inferred from the TD API url:

```
return os.getenv(
            "TD_PRESTO_API", urlparse(self.endpoint).netloc.replace("api", "api-presto")
        )
```

Given the form:

```
api-development.site.treasuredata.com
```

This then results in:

```
api-presto-development.site.treasuredata.com
```

However - the Presto APIs follow the following form:

```
api-development-presto.site.treasuredata.com
```

### Sanity Check

```
>>> curl https://api-development-presto.treasuredata.com
OK%                                                                                                                                                                                                
>>> curl https://api-presto-development.treasuredata.com
curl: (6) Could not resolve host: api-presto-development.treasuredata.com
```

### Fix

Instead of replacing `api` with `api-presto` - we need to decompose the url and replace `stage` with `stage-presto`.
Given that the stage is variable, it has to be derived from the endpoint URL itself.

