### PR TITLE
Release 2.0.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 v2.0.0 (2025-08-05)
 -------------------
 
-- Migrate Migrate presto-python-client to trino-python-client
+- Migrate presto-python-client to trino-python-client
 - Add support for Python 3.12, 3.13
 - Drop support for Python 3.8
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+v2.0.0 (2025-08-05)
+-------------------
+
+- Migrate Migrate presto-python-client to trino-python-client
+- Add support for Python 3.12, 3.13
+- Drop support for Python 3.8
+
 v1.9.0 (2025-03-21)
 -------------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pytd
-version = 1.9.0
+version = 2.0.0
 summary = Treasure Data Driver for Python
 author = Treasure Data
 author_email = support@treasure-data.com


### PR DESCRIPTION
Changelogs:
- Migrate presto-python-client to trino-python-client
- Add support for Python 3.12, 3.13
- Drop support for Python 3.8