### PR TITLE
Support infinity/nan for InsertIntoWriter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,5 @@ venv.bak/
 .mypy_cache/
 .dmypy.json
 dmypy.json
+
+.agent

--- a/pytd/tests/test_writer.py
+++ b/pytd/tests/test_writer.py
@@ -189,7 +189,10 @@ class InsertIntoWriterTestCase(unittest.TestCase):
             "foo", "bar", list(df.itertuples(index=False, name=None)), df.columns
         )
         # column 'b' is handled as float64 because of null
-        q_expected = "INSERT INTO foo.bar (a, b, c) VALUES (1, null, 4), (2, 3.0, null)"
+        # With new implementation, np.nan in float columns becomes nan() instead of null
+        q_expected = (
+            "INSERT INTO foo.bar (a, b, c) VALUES (1, nan(), 4), (2, 3.0, null)"
+        )
         self.assertEqual(q, q_expected)
 
     def test_close(self):

--- a/pytd/writer.py
+++ b/pytd/writer.py
@@ -61,7 +61,8 @@ def _replace_pd_na(dataframe):
         for column in dataframe.columns:
             if dataframe[column].dtype.kind != "f":  # Not float type
                 # Only replace pd.NA in non-float columns
-                # Keep NaN and Infinity in float columns as they are handled correctly by msgpack
+                # Keep NaN and Infinity in float columns as they are handled correctly
+                # by msgpack
                 mask = dataframe[column].apply(
                     lambda x: pd.isna(x)
                     and not (

--- a/pytd/writer.py
+++ b/pytd/writer.py
@@ -1,6 +1,7 @@
 import abc
 import gzip
 import logging
+import math
 import os
 import tempfile
 import time
@@ -188,6 +189,45 @@ class InsertIntoWriter(Writer):
     INSERT INTO query in Presto.
     """
 
+    def _format_value_for_trino(self, value):
+        """Convert a value to appropriate string format for use in Presto queries.
+
+        Parameters
+        ----------
+        value : any
+            The value to convert
+
+        Returns
+        -------
+        str
+            String representation usable in Presto queries
+        """
+        # Handle string values with quote escaping
+        if isinstance(value, str):
+            return f"""'{value.replace("'", "''")}'"""
+
+        # Detect infinity (excluding nan)
+        if (
+            isinstance(value, (int, float, np.number))
+            and not pd.isnull(value)
+            and math.isinf(value)
+        ):
+            if value > 0:
+                return "infinity()"
+            else:
+                return "-infinity()"
+
+        # Detect nan specifically
+        if isinstance(value, (int, float, np.number)) and math.isnan(value):
+            return "nan()"
+
+        # Handle other null values (pd.NA, pd.NaT, None)
+        if pd.isnull(value):
+            return "null"
+
+        # Handle other numeric values
+        return str(value)
+
     def write_dataframe(self, dataframe, table, if_exists):
         """Write a given DataFrame to a Treasure Data table.
 
@@ -297,18 +337,7 @@ class InsertIntoWriter(Writer):
         """
         rows = []
         for tpl in list_of_tuple:
-            # InsertIntoWriter kicks Presto (Trino).
-            # Following the list comprehension makes a single quote duplicated because
-            # Presto allows users to escape a single quote with another single quote.
-            # e.g. 'John Doe''s name' is converted to "John Doe's name" on Presto.
-            list_of_value_strings = [
-                (
-                    f"""'{e.replace("'", "''")}'"""
-                    if isinstance(e, str)
-                    else ("null" if pd.isnull(e) else str(e))
-                )
-                for e in tpl
-            ]
+            list_of_value_strings = [self._format_value_for_trino(e) for e in tpl]
             rows.append(f"({', '.join(list_of_value_strings)})")
 
         return (

--- a/pytd/writer.py
+++ b/pytd/writer.py
@@ -53,20 +53,6 @@ def _replace_pd_na(dataframe):
         dataframe.replace(replace_dict, inplace=True)
 
 
-def _replace_special_float_values(dataframe):
-    """Replace infinity values (inf, -inf) with None for BulkImportWriter compatibility.
-    NaN values will be handled by _replace_pd_na() afterward."""
-    for column in dataframe.columns:
-        if dataframe[column].dtype.kind == "f":  # Float type
-            series = dataframe[column]
-            # Create mask for infinity values only (not NaN)
-            inf_mask = np.isinf(series)
-            if inf_mask.any():
-                # Convert to Float64 dtype to allow None values while preserving numeric type
-                dataframe[column] = dataframe[column].astype("Float64")
-                dataframe.loc[inf_mask, column] = None
-
-
 def _to_list(ary):
     # Return None if None, np.nan, pd.NA, or np.nan in 0-d array given
     if ary is None or _is_np_nan(ary) or _is_0d_nan(ary) or _is_pd_na(ary):
@@ -534,7 +520,7 @@ class BulkImportWriter(Writer):
                 dataframe.to_csv(fp.name)
                 fps.append(fp)
             elif fmt == "msgpack":
-                _replace_special_float_values(dataframe)
+                _replace_pd_na(dataframe)
                 num_rows = len(dataframe)
                 # chunk number of records should not exceed 200 to avoid OSError
                 _chunk_record_size = max(chunk_record_size, num_rows // 200)


### PR DESCRIPTION
This PR supports 
- NaN
- infinity/-infinity
in float64 type for InsertIntoWriter.

Confirmed that the following dataframe ingested as expected.

```py
def create_test_dataframe():
    """Create a test DataFrame with special float values."""
    return pd.DataFrame({
        'id': [1, 2, 3, 4, 5, 6, 7, 8],
        'float_col': [1.0, np.nan, np.inf, -np.inf, 2.5, 0.0, -1.5, 100.123],
        'int_col': [10, 20, 30, 40, 50, 60, 70, 80],
        'str_col': ['normal', 'value', 'with', 'special', "O'Brien", "can't", "It's", 'data'],
        'bool_col': [True, False, True, False, True, False, True, False],
        'nullable_int': pd.array([1, pd.NA, 3, 4, pd.NA, 6, 7, 8], dtype='Int64'),
        'nullable_str': pd.array(['a', pd.NA, 'c', 'd', 'e', pd.NA, 'g', 'h'], dtype='string'),
        'time': int(time.time())
    })
```